### PR TITLE
fix: Comments out build line since tests run builds on each sample

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           # https://playwright.dev/docs/installation/#skip-browser-downloads
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      - run: npm run build
+      # - run: npm run build
       - run: npx playwright install-deps
       - run: npx playwright install
       - run: npx playwright test -- --shard=${{matrix.shard}}/8


### PR DESCRIPTION
There is no `build` command at this level so it's expected to fail. We shouldn't need to run the build command here, since that's already taken care of in the test. 