### PR TITLE
fix: Updates e2e and release-please

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
       # - run: npm run build
       - run: npx playwright install-deps
       - run: npx playwright install
-      - run: npx playwright test -- --shard=${{matrix.shard}}/8
+      - run: npx playwright test
         env:
           CI: true
       - name: Push test report to artifacts

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,12 +18,12 @@
 ##   handy version incrementing which is useful for us.
 
 on:
-    push:
-      branches: [main]
+  push:
+    branches: [main]
 
 permissions:
-    contents: write
-    pull-requests: write
+  contents: write
+  pull-requests: write
 
 name: Release Please
 
@@ -38,35 +38,7 @@ jobs:
             release-type: node
             token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
             package-name: "@googlemaps-samples/js-api-samples"
-            bump-minor-pre-major: true
-  
-        - if: ${{ steps.release.outputs.release_created }}
-          name: Checkout
-          uses: actions/checkout@v3
-  
-        - if: ${{ steps.release.outputs.release_created }}
-          name: Setup Node
-          uses: actions/setup-node@v3
-          with:
-            node-version: 20
-            cache: 'npm' # Cache node_modules
-  
-        - if: ${{ steps.release.outputs.release_created }}
-          name: Install Dependencies
-          run: npm ci
-  
-        - if: ${{ steps.release.outputs.release_created }}
-          name: Build
-          run: npm run build
-  
-        - if: ${{ steps.release.outputs.release_created }}
-          name: Update dist
-          run: |
-            git config --global user.name 'googlemaps-bot'
-            git config --global user.email 'googlemaps-bot@google.com'
-            git add dist
-            git commit -m "chore: update dist folder [skip ci]" || true
-            git push origin
+            bump-minor-pre-major: true 
   
         # Upload /dist to the Cloud bucket.
         - if:  ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
 Updates e2e to not use sharding with Playwright; Removes unnecessary parts of release-please, since we're not pushing releases to Node anymore (we kept the version bump).