### PR TITLE
fix: Changed dependabot.yml to use GITHUB_TOKEN secret.

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
-      GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: approve
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
Dependabot pull requests have restricted access to secrets for security reasons.  secrets.SYNCED_GITHUB_TOKEN_REPO is not available in this context.  We need to use secrets.GITHUB_TOKEN which is automatically available for Dependabot PRs. This token has the necessary permissions for the workflow to approve and merge the pull request.