### PR TITLE
fix: Adds a script to generate the default index file for Firebase.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Maps JSAPI Samples</title>
+</head>
+<body>
+<!-- Default top-level index for Firebase Hosting -->
+<h1>Maps JSAPI Samples</h1>
+<ul>
+  <li><a href='add-map/app/dist/'>add-map</a></li>
+  <li><a href='map-simple/app/dist/'>map-simple</a></li>
+  <li><a href='place-text-search/app/dist/'>place-text-search</a></li>
+</ul>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Samples for the Google Maps JavaScript API.",
   "scripts": {
-    "build-all": "npm run clean && npm run build --workspaces",
-    "clean": "bash samples/clean.sh"
+    "build-all": "npm run generate-index && npm run clean && npm run build --workspaces",
+    "clean": "bash samples/clean.sh",
+    "generate-index": "bash samples/generate-index.sh"
   },
   "workspaces": [
     "samples/*"

--- a/samples/generate-index.sh
+++ b/samples/generate-index.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Generate a new index.html for Firebase App Hosting.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" # Script directory (/samples)
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")  # Get the parent directory (js-api-samples)
+DIST_DIR="$PROJECT_ROOT/dist"
+
+# Create the output file.
+OUTPUT_FILE="index.html"
+
+# Generate the HTML document.
+echo "<!DOCTYPE html>" > "${OUTPUT_FILE}"
+echo "<html>" >> "${OUTPUT_FILE}"
+echo "<head>" >> "${OUTPUT_FILE}"
+echo "<title>Maps JSAPI Samples</title>" >> "${OUTPUT_FILE}"
+echo "</head>" >> "${OUTPUT_FILE}"
+echo "<body>" >> "${OUTPUT_FILE}"
+echo "<!-- Default top-level index for Firebase Hosting -->" >> "${OUTPUT_FILE}"
+echo "<h1>Maps JSAPI Samples</h1>" >> "${OUTPUT_FILE}"
+echo "<ul>" >> "${OUTPUT_FILE}"
+
+# Iterate through sample directories.
+find "${SCRIPT_DIR}" -maxdepth 1 -mindepth 1 -type d | while read -r subdir; do
+
+# Extract the directory name.
+DIR_NAME=$(basename "${subdir}")
+
+# Construct the link.
+LINK_URL="${DIR_NAME}/app/dist/"
+LINK_TEXT="${DIR_NAME}"
+
+# Create the list item.
+echo "  <li><a href='${LINK_URL}'>${LINK_TEXT}</a></li>" >> "${OUTPUT_FILE}"
+done
+
+echo "</ul>" >> "${OUTPUT_FILE}"
+echo "</body>" >> "${OUTPUT_FILE}"
+echo "</html>" >> "${OUTPUT_FILE}"
+
+echo "HTML file generated: ${OUTPUT_FILE}"
+
+echo "from ${SCRIPT_DIR}/${OUTPUT_FILE}"
+echo "to ${DIST_DIR}/${OUTPUT_FILE}"
+
+cp "${PROJECT_ROOT}/${OUTPUT_FILE}" "${DIST_DIR}/${OUTPUT_FILE}"


### PR DESCRIPTION
This will hopefully solve the Firebase backend issue. Now the build process generates an index.html with a list of whatever's in /samples. It copies it to /dist, where the deployment can see it.