### PR TITLE
fix: Removes emulators block from firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,14 +6,5 @@
       "**/.*",
       "**/node_modules/**"
     ]
-  },
-  "emulators": {
-    "hosting": {
-      "port": 8080
-    },
-    "ui": {
-      "enabled": false
-    },
-    "singleProjectMode": true
   }
 }

--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
 <!-- Default top-level index for Firebase Hosting -->
 <h1>Maps JSAPI Samples</h1>
 <ul>
-  <li><a href='add-map/app/dist/'>add-map</a></li>
-  <li><a href='map-simple/app/dist/'>map-simple</a></li>
-  <li><a href='place-autocomplete-map/app/dist/'>place-autocomplete-map</a></li>
-  <li><a href='place-autocomplete-element/app/dist/'>place-autocomplete-element</a></li>
-  <li><a href='place-text-search/app/dist/'>place-text-search</a></li>
+  <li><a href='/samples/add-map/app/dist/'>add-map</a></li>
+  <li><a href='/samples/map-simple/app/dist/'>map-simple</a></li>
+  <li><a href='/samples/place-autocomplete-map/app/dist/'>place-autocomplete-map</a></li>
+  <li><a href='/samples/place-autocomplete-element/app/dist/'>place-autocomplete-element</a></li>
+  <li><a href='/samples/place-text-search/app/dist/'>place-text-search</a></li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
The cloud run logs said something about 8080, I put that there to make local testing easier, but there are other ways to do that.