### PR TITLE
fix: Updates index page generator with revised path.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
 <!-- Default top-level index for Firebase Hosting -->
 <h1>Maps JSAPI Samples</h1>
 <ul>
-  <li><a href='/samples/add-map/app/dist/'>add-map</a></li>
-  <li><a href='/samples/map-simple/app/dist/'>map-simple</a></li>
-  <li><a href='/samples/place-autocomplete-map/app/dist/'>place-autocomplete-map</a></li>
-  <li><a href='/samples/place-autocomplete-element/app/dist/'>place-autocomplete-element</a></li>
-  <li><a href='/samples/place-text-search/app/dist/'>place-text-search</a></li>
+  <li><a href='/samples/add-map/dist'>add-map</a></li>
+  <li><a href='/samples/map-simple/dist'>map-simple</a></li>
+  <li><a href='/samples/place-autocomplete-map/dist'>place-autocomplete-map</a></li>
+  <li><a href='/samples/place-autocomplete-element/dist'>place-autocomplete-element</a></li>
+  <li><a href='/samples/place-text-search/dist'>place-text-search</a></li>
 </ul>
 </body>
 </html>

--- a/samples/app.sh
+++ b/samples/app.sh
@@ -26,7 +26,7 @@ cp "${OUTPUT_DIR}/${NAME}/package.json" "${APP_DIR}/package.json"
 cp "${OUTPUT_DIR}/${NAME}/tsconfig.json" "${APP_DIR}/tsconfig.json"
 cp "${OUTPUT_DIR}/${NAME}/README.md" "${APP_DIR}/README.md"
 cp "${OUTPUT_DIR}/.env" "${APP_DIR}/.env" # TODO: Update the .env with the new API key.
-cp -r "${OUTPUT_DIR}/${NAME}/dist/." "${MAIN_DIR}/"
+cp -r "${OUTPUT_DIR}/${NAME}/dist" "${MAIN_DIR}"
 echo "OUTPUT_DIR ${OUTPUT_DIR}"
 echo "MAIN_DIR ${MAIN_DIR}"
 
@@ -47,3 +47,6 @@ cat > "${APP_DIR}/.eslintsrc.json" << EOF
   }
 }
 EOF
+
+
+## TODO: Update this to copy

--- a/samples/generate-index.sh
+++ b/samples/generate-index.sh
@@ -2,6 +2,8 @@
 
 # Generate a new index.html for Firebase App Hosting.
 
+#https://maps-docs-team.web.app/samples/place-autocomplete-map/
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" # Script directory (/samples)
 PROJECT_ROOT=$(dirname "$SCRIPT_DIR")  # Get the parent directory (js-api-samples)
 DIST_DIR="$PROJECT_ROOT/dist"
@@ -27,7 +29,7 @@ find "${SCRIPT_DIR}" -maxdepth 1 -mindepth 1 -type d | while read -r subdir; do
 DIR_NAME=$(basename "${subdir}")
 
 # Construct the link.
-LINK_URL="/samples/${DIR_NAME}/app/dist/"
+LINK_URL="/samples/${DIR_NAME}/dist"
 LINK_TEXT="${DIR_NAME}"
 
 # Create the list item.


### PR DESCRIPTION
This was done since we changed the output path for Vite build outputs so that /dist contents match those of /dist within the source folder. 