### PR TITLE
feat: Adds post-build hook.

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -1,0 +1,25 @@
+name: dist-pr
+
+on:
+  push:
+    branches:
+      - dist  # Trigger the workflow on pushes to the dist branch
+
+jobs:
+  approve-and-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'github-actions[bot]' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create Pull Request
+        id: cpr
+        run: |
+          echo "pull_request_url=$(gh pr create --title "chore: automated output update (dist)" --body "This PR contains updated build output from the dist branch." --base main --head dist)" >> $GITHUB_OUTPUT
+
+      - name: Approve PR
+        run: gh pr review --approve ${{ steps.cpr.outputs.pull_request_url }}
+
+      - name: Merge PR
+        run: gh pr merge --auto --squash --delete-branch ${{ steps.cpr.outputs.pull_request_url }}

--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: dist-pr
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## Runs the release-please action for all new pushes to the main branch.
-##   This updates the CHANGELOG.md, and uploads the contents of /dist to
-##   the Cloud bucket. It does NOT release to Node, but it provides
-##   handy version incrementing which is useful for us.
-
 name: Release
 
 on:
@@ -44,7 +39,7 @@ jobs:
         with:
           node-version: '22.x'
       - run: npm i
-      - run: npm run build-all
+      - run: npm run build-prod
 
       - uses: google-github-actions/auth@v1
         with:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Samples for the Google Maps JavaScript API.",
   "scripts": {
     "build-all": "npm run generate-index && npm run clean && npm run build --workspaces",
+    "build-prod": "npm run generate-index && npm run clean && npm run build --workspaces && ./.git/hooks/post-build",
     "clean": "bash samples/clean.sh",
     "generate-index": "bash samples/generate-index.sh"
   },

--- a/post-build.sh
+++ b/post-build.sh
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
 # Checkout the dist branch

--- a/post-build.sh
+++ b/post-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Checkout the dist branch
+git checkout dist || git checkout -b dist
+
+# Add and commit the changes to the dist folder
+git add dist
+git commit -m "Update dist folder"
+
+# Push the changes to the dist branch
+git push origin dist


### PR DESCRIPTION
This change would make Rube Goldberg proud! It does the following:

1. When a PR is merged, release workflow is triggered. It runs all the things including build-prod.
2. The build-prod script triggers a git hook (post-build.sh).
3. The post-build hook checks out dist, adds, creates a commit, and pushes to a dist branch on origin.
4. The dist-pr.yml workflow is triggered only on pushes to dist. If the actor is github-actions[bot], it creates, approves, and merges a PR with all of /dist changes, then deletes the branch.