### PR TITLE
fix: Updates build-prod to correctly reference post-build.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Samples for the Google Maps JavaScript API.",
   "scripts": {
     "build-all": "npm run generate-index && npm run clean && npm run build --workspaces",
-    "build-prod": "npm run generate-index && npm run clean && npm run build --workspaces && ./.git/hooks/post-build.sh",
+    "build-prod": "npm run generate-index && npm run clean && npm run build --workspaces && bash post-build.sh",
     "clean": "bash samples/clean.sh",
     "generate-index": "bash samples/generate-index.sh"
   },


### PR DESCRIPTION
I had accidentally included the local link for non-shared hooks.