### PR TITLE
feat: Adds Place AC session example; adds fixes for b/395793115.

### DIFF
--- a/samples/new1.sh
+++ b/samples/new1.sh
@@ -12,10 +12,10 @@
 #  3. ./new1.sh
 
 # AUTHOR: Update these values!
-NAME="map-simple" # The name of the folder to create (for example "map-simple").
-REGION_TAG="maps_map_simple" # The region tag to use for the JSHTML (for example "maps_map_simple").
-TITLE="Simple map" # The title of the example.
-API_LOADER="api_loader_dynamic" # The type of loader to use (api_loader_dynamic or api_loader_default).
+NAME="place-autocomplete-data-session" # The name of the folder to create (for example "map-simple").
+REGION_TAG="maps_place_autocomplete_data_session" # The region tag to use for the JSHTML (for example "maps_map_simple").
+TITLE="Place Autocomplete Data API Session" # The title of the example.
+API_LOADER="api_loader_default" # The type of loader to use (api_loader_dynamic or api_loader_default).
 
 # Path to the source folder for the repo archive; substitute with your own path.
 INPUT_DIR=/Users/wfrench/Downloads/js-samples-main

--- a/samples/place-autocomplete-data-session/README.md
+++ b/samples/place-autocomplete-data-session/README.md
@@ -1,0 +1,33 @@
+# Google Maps JavaScript Sample
+
+This sample is generated from @googlemaps/js-samples located at
+https://github.com/googlemaps-samples/js-api-samples.
+
+## Setup
+
+### Before starting run:
+
+`npm i`
+
+### Run an example on a local web server
+
+First `cd` to the folder for the sample to run, then:
+
+`npm start`
+
+### Build an individual example
+
+From `samples/`:
+
+`npm run build --workspace=sample-name/`
+
+### Build all of the examples.
+
+From `samples/`:
+
+`npm run build-all`
+
+## Feedback
+
+For feedback related to this sample, please open a new issue on
+[GitHub](https://github.com/googlemaps-samples/js-api-samples/issues).

--- a/samples/place-autocomplete-data-session/index.html
+++ b/samples/place-autocomplete-data-session/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!--
+ @license
+ Copyright 2019 Google LLC. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+<!-- [START maps_place_autocomplete_data_session] -->
+<html>
+  <head>
+    <title>Place Autocomplete Data API Session</title>
+
+    <link rel="stylesheet" type="text/css" href="./style.css" />
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body>
+    <!-- // [START maps_place_autocomplete_data_session_html] -->
+    <input id="input" type="text" placeholder="Search for a place..." />
+    <div id="title"></div>
+    <ul id="results"></ul>
+    <img
+      class="powered-by-google"
+      src="https://storage.googleapis.com/geo-devrel-public-buckets/powered_by_google_on_white.png"
+      alt="Powered by Google"
+    />
+    <!-- // [END maps_place_autocomplete_data_session_html] -->
+
+    <!-- 
+      The `defer` attribute causes the script to execute after the full HTML
+      document has been parsed. For non-blocking uses, avoiding race conditions,
+      and consistent behavior across browsers, consider loading using Promises. See
+      https://developers.google.com/maps/documentation/javascript/load-maps-js-api
+      for more information.
+      -->
+    <script
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=init&libraries=places&v=weekly"
+      defer
+    ></script>
+  </body>
+</html>
+<!-- [END maps_place_autocomplete_data_session] -->

--- a/samples/place-autocomplete-data-session/index.js
+++ b/samples/place-autocomplete-data-session/index.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// [START maps_place_autocomplete_data_session]
+let title;
+let results;
+let input;
+let token;
+// Add an initial request body.
+let request = {
+    input: "",
+    locationRestriction: { west: -122.44, north: 37.8, east: -122.39, south: 37.78 },
+    origin: { lat: 37.7893, lng: -122.4039 },
+    includedPrimaryTypes: ["restaurant"],
+    language: "en-US",
+    region: "us",
+    sessionToken: null,
+};
+async function init() {
+    title = document.getElementById('title');
+    results = document.getElementById('results');
+    input = document.querySelector("input");
+    input.addEventListener("input", makeAcRequest);
+    await refreshToken(); // Await the refreshToken call here.
+}
+async function makeAcRequest(input) {
+    // Reset elements and exit if an empty string is received.
+    if (input.target.value == '') {
+        title.innerText = '';
+        results.replaceChildren();
+        return;
+    }
+    // Add the latest char sequence to the request.
+    request.input = input.target.value;
+    await refreshToken(); //refresh the token before each request.
+    // Fetch autocomplete suggestions and show them in a list.
+    // @ts-ignore
+    const { suggestions } = await google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
+    title.innerText = 'Query predictions for "' + request.input + '"';
+    // Clear the list first.
+    results.replaceChildren();
+    for (const suggestion of suggestions) {
+        const placePrediction = suggestion.placePrediction;
+        // Create a link for the place, add an event handler to fetch the place.
+        const a = document.createElement('a');
+        a.addEventListener('click', () => {
+            onPlaceSelected(placePrediction.toPlace());
+        });
+        a.innerText = placePrediction.text.toString();
+        // Create a new list element.
+        const li = document.createElement('li');
+        li.appendChild(a);
+        results.appendChild(li);
+    }
+}
+// Event handler for clicking on a suggested place.
+async function onPlaceSelected(place) {
+    await place.fetchFields({
+        fields: ['displayName', 'formattedAddress'],
+    });
+    let placeText = document.createTextNode(place.displayName + ': ' + place.formattedAddress);
+    results.replaceChildren(placeText);
+    title.innerText = 'Selected Place:';
+    input.value = '';
+    await refreshToken();
+}
+// Helper function to refresh the session token.
+async function refreshToken() {
+    // Create a new session token and add it to the request.
+    token = new google.maps.places.AutocompleteSessionToken();
+    request.sessionToken = token;
+}
+window.init = init;
+export {};

--- a/samples/place-autocomplete-data-session/index.ts
+++ b/samples/place-autocomplete-data-session/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// [START maps_place_autocomplete_data_session]
+let title;
+let results;
+let input;
+let token;
+
+// Add an initial request body.
+let request = {
+    input: "",
+    locationRestriction: { west: -122.44, north: 37.8, east: -122.39, south: 37.78 },
+    origin: { lat: 37.7893, lng: -122.4039 },
+    includedPrimaryTypes: ["restaurant"],
+    language: "en-US",
+    region: "us",
+    sessionToken: null,
+};
+
+async function init() {
+    title = document.getElementById('title');
+    results = document.getElementById('results');
+    input = document.querySelector("input");
+    input.addEventListener("input", makeAcRequest);
+    await refreshToken(); // Await the refreshToken call here.
+}
+
+async function makeAcRequest(input) {
+    // Reset elements and exit if an empty string is received.
+    if (input.target.value == '') {
+        title.innerText = '';
+        results.replaceChildren();
+        return;
+    }
+
+    // Add the latest char sequence to the request.
+    request.input = input.target.value;
+    await refreshToken(); //refresh the token before each request.
+
+    // Fetch autocomplete suggestions and show them in a list.
+    // @ts-ignore
+    const { suggestions } = await google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
+
+    title.innerText = 'Query predictions for "' + request.input + '"';
+
+    // Clear the list first.
+    results.replaceChildren();
+
+    for (const suggestion of suggestions) {
+        const placePrediction = suggestion.placePrediction;
+
+        // Create a link for the place, add an event handler to fetch the place.
+        const a = document.createElement('a');
+        a.addEventListener('click', () => {
+            onPlaceSelected(placePrediction!.toPlace());
+        });
+        a.innerText = placePrediction!.text.toString();
+
+        // Create a new list element.
+        const li = document.createElement('li');
+        li.appendChild(a);
+        results.appendChild(li);
+    }
+}
+
+// Event handler for clicking on a suggested place.
+async function onPlaceSelected(place) {
+    await place.fetchFields({
+        fields: ['displayName', 'formattedAddress'],
+    });
+    let placeText = document.createTextNode(place.displayName + ': ' + place.formattedAddress);
+    results.replaceChildren(placeText);
+    title.innerText = 'Selected Place:';
+    input.value = '';
+    await refreshToken();
+}
+
+// Helper function to refresh the session token.
+async function refreshToken() {
+    // Create a new session token and add it to the request.
+    token = new google.maps.places.AutocompleteSessionToken();
+    request.sessionToken = token;
+}
+
+declare global {
+    interface Window {
+      init: () => void;
+    }
+  }
+  window.init = init;
+// [END maps_place_autocomplete_data_session]
+export { };

--- a/samples/place-autocomplete-data-session/package.json
+++ b/samples/place-autocomplete-data-session/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@js-api-samples/place-autocomplete-data-session",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc && bash ../jsfiddle.sh place-autocomplete-data-session && bash ../app.sh place-autocomplete-data-session && bash ../docs.sh place-autocomplete-data-session && npm run build:vite --workspace=.",
+    "test": "tsc && npm run build:vite --workspace=.",
+    "start": "tsc && vite build --base './' && vite",
+    "build:vite": "vite build --base './'",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    
+  }
+}

--- a/samples/place-autocomplete-data-session/place-autocomplete-data-session.jshtml
+++ b/samples/place-autocomplete-data-session/place-autocomplete-data-session.jshtml
@@ -1,0 +1,19 @@
+
+{% spaceless %}{% include "maps/documentation/javascript/examples/full/_apikey.html" %}{% endspaceless %}<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <meta charset="utf-8">
+    <title>Place Autocomplete Data API Session</title>
+    <style>
+{% includecode content_path="maps/documentation/javascript/examples/samples/place-autocomplete-data-session/style.css" region_tag="maps_place_autocomplete_data_session" html_escape="False" %}
+    </style>
+  </head>
+  <body>
+{% includecode content_path="maps/documentation/javascript/examples/samples/place-autocomplete-data-session/index.html" region_tag="maps_place_autocomplete_data_session_body" html_escape="False" %}
+{{ api_loader_default }}
+    <script>
+{% includecode content_path="maps/documentation/javascript/examples/samples/place-autocomplete-data-session/index.js" region_tag="maps_place_autocomplete_data_session" html_escape="False" %}
+    </script>
+  </body>
+</html>

--- a/samples/place-autocomplete-data-session/style.css
+++ b/samples/place-autocomplete-data-session/style.css
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* [START maps_place_autocomplete_data_session] */
+/* 
+ * Always set the map height explicitly to define the size of the div element
+ * that contains the map. 
+ */
+#map {
+  height: 100%;
+}
+
+/* 
+ * Optional: Makes the sample page fill the window. 
+ */
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: underline;
+  color: blue;
+}
+
+input {
+  width: 300px;
+}
+
+/* [END maps_place_autocomplete_data_session] */

--- a/samples/place-autocomplete-data-session/tsconfig.json
+++ b/samples/place-autocomplete-data-session/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "strict": true,
+    "noImplicitAny": false,
+    "lib": [
+      "es2015",
+      "esnext",
+      "es6",
+      "dom",
+      "dom.iterable"
+    ],
+    "moduleResolution": "Node",
+    "jsx": "preserve"
+  }
+}


### PR DESCRIPTION
This PR makes the following changes:
- Uses `await refreshToken()` whenever updating the session token.
- The `refreshToken` function no longer returns `request` object; rather, it updates the `request.sessionToken` property.
- The request object now initializes `sessionToken` to null.