### PR TITLE
fix: Update release.yml to use googlemaps-bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
             token: ${{ secrets.GITHUB_TOKEN }}
         - name: Set Git Identity
           run: |
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git config --global user.name 'googlemaps-bot'
+            git config --global user.email 'googlemaps-bot@users.noreply.github.com'
         - uses: actions/cache@v3
           with:
             path: ~/.npm


### PR DESCRIPTION
Since github-actions bot does not have permissions, seems like using googlemaps-bot is the only real choice here. Convince me otherwise.