### PR TITLE
Update post-build.sh to pull first

### DIFF
--- a/post-build.sh
+++ b/post-build.sh
@@ -24,6 +24,8 @@ if ! git show-ref --verify --quiet refs/heads/dist; then
     git branch dist
 fi
 
+git pull origin dist || true
+
 # Checkout the dist branch
 git checkout dist || git checkout -b dist
 


### PR DESCRIPTION
This change addresses:

 ! [rejected]        dist -> dist (fetch first)
error: failed to push some refs to 'https://github.com/googlemaps-samples/js-api-samples'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.