### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -26,7 +26,8 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v3
           with:
-            ref: ${{ github.event.after }}  # Check out the *new* commit on dist
+            # No ref specified: defaults to checking out the 'dist' branch
+            token: ${{ secrets.GH_MERGE_TOKEN }}
 
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Removed the explicit ref, as that would have left things in a detached head state (medieval times). Omitting the ref causes it to default to checking out the entire branch. This permits the subsequent workflows to access the needed parts of the branch.