### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -42,3 +42,4 @@ jobs:
               automated pr
               dist-update
             draft: false # Or true, if you want to review before enabling auto-merge
+            push-to-org-branch: 'dist'


### PR DESCRIPTION
Adds push-to-org-branch to correctly identify `dist` as the branch of interest. This ensures that things are fetched in the correct order, avoiding an issue where main and dist don't match.