### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -42,4 +42,3 @@ jobs:
               automated pr
               dist-update
             draft: false # Or true, if you want to review before enabling auto-merge
-            push-to-org-branch: 'dist'


### PR DESCRIPTION
Removes push-to-org-branch, that's from an earlier version of the cpr action, and it didn't work! Keeping the previous change of not specifying ref.