### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -26,8 +26,11 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v3
           with:
-            ref: ${{ github.event.before }} # Checkout previous commit on dist.
+            ref: dist
             token: ${{ secrets.GH_MERGE_TOKEN }}
+        
+        - name: Checkout Previous Commit
+          run: git checkout ${{ github.event.before }}
 
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5
@@ -36,8 +39,8 @@ jobs:
             commit-message: 'chore: automated output update (dist)'
             title: 'chore: automated output update (dist)'
             body: 'This PR contains updated build output from the dist branch.'
-            branch: 'dist-to-main-pr'  # Use a dedicated PR branch
-            base: main
+            branch: 'dist-to-main-pr'  # PR branch
+            base: main # Target branch
             labels: |
               automated pr
               dist-update


### PR DESCRIPTION
Updates dist-pr workflow as follows:
- Adds ref: dist to explicitly checkout the dist branch (avoid the detached head state so popular in medieval days)
- Add a step to checkout the previous commit, so that the CPR action has something to compare against.