### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -28,6 +28,7 @@ jobs:
           with:
             ref: dist
             token: ${{ secrets.GH_MERGE_TOKEN }}
+            fetch-depth: 2
         
         - name: Checkout Previous Commit
           run: git checkout ${{ github.event.before }}


### PR DESCRIPTION
Adds fetch-depth: 2. This tells actions/checkout to fetch the current commit and the preceding commit, ensuring that github.event.before will be available. Should solve the newly resurrected detached head problem.