### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -28,10 +28,14 @@ jobs:
           with:
             ref: dist
             token: ${{ secrets.GH_MERGE_TOKEN }}
-            fetch-depth: 2
+
+        - name: Fetch Previous Commit
+          run: |
+            git fetch origin ${{ github.event.before }}:refs/remotes/origin/before_commit
         
         - name: Checkout Previous Commit
-          run: git checkout ${{ github.event.before }}
+          run: |
+            git checkout refs/remotes/origin/before_commit
 
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Changes the way the workflow checks things out.
- Adds step to fetch previous commit.
- Changes checkout previous commit to check out the commit using the new local ref that we just created.

Gemini explains it like this (so much collaboration): Why This Should Work

Explicit Fetch: We're explicitly fetching the exact commit we need, bypassing any potential issues with fetch-depth calculations.
Local Ref: We're creating a local ref, making the checkout unambiguous.
Branch Context: We start by checking out the branch, then we check out a specific commit.