### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -28,14 +28,11 @@ jobs:
           with:
             ref: dist
             token: ${{ secrets.GH_MERGE_TOKEN }}
+            fetch-depth: 0 # Fetch entire history
 
-        - name: Fetch Previous Commit
-          run: |
-            git fetch origin ${{ github.event.before }}:refs/remotes/origin/before_commit
-        
-        - name: Checkout Previous Commit
-          run: |
-            git checkout refs/remotes/origin/before_commit
+        - name: Get Previous Commit SHA
+          id: get-previous-commit
+          run: echo "previous_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
 
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5
@@ -50,3 +47,4 @@ jobs:
               automated pr
               dist-update
             draft: false # Or true, if you want to review before enabling auto-merge
+            head: dist


### PR DESCRIPTION
Attempt to correct a previous miscalculation regarding the logic here. You must be on a branch for the CPR steps to work. This change does the following:
- Adds fetch-depth so that the entire history gets fetched.
- Get the SHA hash from the previous commit.
- Create the PR from the dist branch. Now, the action compares the current dist branch (which has the new commit from release.yml) with main and creates a pull request.