### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -26,13 +26,7 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v3
           with:
-            ref: dist
             token: ${{ secrets.GH_MERGE_TOKEN }}
-            fetch-depth: 0 # Fetch entire history
-
-        - name: Get Previous Commit SHA
-          id: get-previous-commit
-          run: echo "previous_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
 
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5
@@ -47,4 +41,3 @@ jobs:
               automated pr
               dist-update
             draft: false # Or true, if you want to review before enabling auto-merge
-            head: dist


### PR DESCRIPTION
Another in a seemingly endless series of changes to try and get this workflow to properly create a PR. This change reverts the file back to a simpler state:
- Removes ref from checkout to ensure the dist branch is correctly checked out. Hopefully we'll avoid a detached head (although at this point decapitation is beginning to sound like a good option)
- Provide onlhy branch and base, and trust the CPR step to execute as intended. We were being far too clever before, and it's not just an ego thing: it's existential!!!