### PR TITLE
fix: Update dist-pr.yml

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Create Branch for PR
         run: |
             git fetch origin main
-            git checkout -b dist-to-main-pr origin/dist
+            git checkout -b dist-to-main-pr
 
       - name: Create Pull Request
         run: |


### PR DESCRIPTION
Updates step to only fetch the ain branch, since dist-to-main-pr is being created locally off of the current HEAD. Attempt to fix this error:

pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and dist-to-main-pr, Head ref must be a branch (createPullRequest)