### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Commit and Push Changes (to temp branch)
         run: |
           git add dist
-          git commit -m "Update dist folder"
+          git commit -m "Update dist folder [skip ci]" 
           git push --force origin temp-build-branch


### PR DESCRIPTION
Adds [skip ci] to the commit message, to prevent a potential loop with workflows.