### PR TITLE
fix: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Commit and Push Changes (to temp branch)
         run: |
           git add dist index.html
-          git commit -m "Update dist folder" 
+          git commit -m "Update dist folder [skip ci]" 
           git push --force origin temp-build-branch


### PR DESCRIPTION
Adds 'skip ci' to the commit message for the dist push, to prevent it from triggering the workflow again (it will fail, doesn't harm anything but it's gross)