### PR TITLE
fix: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.commits[0].message != 'Update dist folder'
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Removes check for commit message, as we've added a skip ci statement which should be a much better way to handle this condition.