### PR TITLE
fix: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,5 +80,9 @@ jobs:
       - name: Commit and Push Changes (to temp branch)
         run: |
           git add dist index.html
-          git commit -m "Update dist folder [skip ci]" 
-          git push --force origin temp-build-branch
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Update dist folder [skip ci]" 
+            git push --force origin temp-build-branch
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
Adds a conditional to verify that actual changes are made; if no changes are found, the commit and push steps are skipped. This change is intended to prevent failures of the release workflow after the actual changes have already been pushed (the only remaining changes are package-lock.json and a gh hash of some sort). 