### PR TITLE
fix: Tweaks to Places UI Kit examples.

### DIFF
--- a/samples/ui-kit-place-details/index.html
+++ b/samples/ui-kit-place-details/index.html
@@ -13,9 +13,8 @@
     <script type="module" src="./index.js"></script>
   </head>
   <body>
-    <h1>Click on the map to view place details</h1>
     <!--[START maps_ui_kit_place_details_map] -->
-    <gmp-map center="-37.813,144.963" zoom="2" map-id="DEMO_MAP_ID" style="height: 400px">
+    <gmp-map center="-37.813,144.963" zoom="2" map-id="DEMO_MAP_ID">
       <gmp-place-details
         size="x-large"
         slot="control-inline-start-block-start"></gmp-place-details>

--- a/samples/ui-kit-place-details/style.css
+++ b/samples/ui-kit-place-details/style.css
@@ -20,7 +20,7 @@ h1 {
 }
 
 gmp-map {
-  height: 400px;
+  height: 800px;
 }
 
 gmp-place-details {


### PR DESCRIPTION
This change removes the "click the map" text, and expands the depth by 2x so that the widget can display fully. Otherwise it's hidden and it looks wrong; removes style declaration from gmp-map tag as it only needs to be in one place.