### PR TITLE
Update playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,10 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], },
+      use: { ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--enable-webgl', '--ignore-gpu-blocklist'],
+        },
     },
     /**
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -93,7 +93,7 @@ export default defineConfig({
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
-  ],
+  ]
 
   /* Run your local dev server before starting the tests */
   // webServer: {


### PR DESCRIPTION
Adds launchOptions to enable WebGL, to see if that fixes Playwright test breakage on 3D maps.