### PR TITLE
Update playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,9 +62,9 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
-          args: ['--enable-webgl', '--ignore-gpu-blocklist']
-        }
-    }
+          args: ['--enable-webgl', '--ignore-gpu-blocklist'],
+        },
+    },
     /**
     {
       name: 'firefox',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,8 +59,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], },
-    },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--enable-webgl', '--ignore-gpu-blocklist']
+        }
+    }
     /**
     {
       name: 'firefox',
@@ -90,7 +94,7 @@ export default defineConfig({
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
-  ],
+  ]
 
   /* Run your local dev server before starting the tests */
   // webServer: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
         launchOptions: {
           args: ['--enable-webgl', '--ignore-gpu-blocklist'],
         },
+      },
     },
     /**
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -94,7 +94,7 @@ export default defineConfig({
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
-  ]
+  ],
 
   /* Run your local dev server before starting the tests */
   // webServer: {


### PR DESCRIPTION
Adds launchOptions clause to enable webGL in an attempt to fix some test breakage on 3D maps, which we suspect is caused by raster fallback on the CI side (all runs perfectly on local env).