### PR TITLE
fix: Numerous updates to fix TSC stripping region tags

### DIFF
--- a/samples/advanced-markers-animation/index.ts
+++ b/samples/advanced-markers-animation/index.ts
@@ -109,4 +109,3 @@
 
 initMap();
 // [END maps_advanced_markers_animation]
-export { };

--- a/samples/place-autocomplete-data-session/index.ts
+++ b/samples/place-autocomplete-data-session/index.ts
@@ -97,4 +97,5 @@ declare global {
   }
   window.init = init;
 // [END maps_place_autocomplete_data_session]
+void 0; // No-op to preserve the last region tag comment.
 export { };

--- a/samples/place-autocomplete-element/index.ts
+++ b/samples/place-autocomplete-element/index.ts
@@ -40,4 +40,3 @@ async function initMap(): Promise<void> {
 
 initMap();
 // [END maps_place_autocomplete_element]
-export { };

--- a/samples/place-autocomplete-map/index.ts
+++ b/samples/place-autocomplete-map/index.ts
@@ -83,4 +83,3 @@ function updateInfoWindow(content, center) {
 
 initMap();
 // [END maps_place_autocomplete_map]
-export { };

--- a/samples/place-text-search/index.ts
+++ b/samples/place-text-search/index.ts
@@ -69,5 +69,3 @@ async function findPlaces() {
 
 initMap();
 // [END maps_place_text_search]
-
-export { };

--- a/samples/ui-kit-place-details/index.html
+++ b/samples/ui-kit-place-details/index.html
@@ -21,10 +21,8 @@
       <gmp-advanced-marker></gmp-advanced-marker>
     </gmp-map>
     <!--[END maps_ui_kit_place_details_map] -->
-    <script
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8&libraries=maps&callback=initMap&v=alpha"
-      defer
-    ></script>
+    <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
+        ({key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "alpha"});</script>
   </body>
 </html>
 <!--[END maps_ui_kit_place_details] -->

--- a/samples/ui-kit-place-details/index.ts
+++ b/samples/ui-kit-place-details/index.ts
@@ -56,19 +56,13 @@ async function initMap(): Promise<void> {
     map.innerMap.panTo(adjustedCenter);
   });
 }
+/* [END maps_ui_kit_place_details_event] */
 
 // Helper function to offset the map center.
 function offsetLatLngRight(latLng, longitudeOffset) {
   const newLng = latLng.lng() + longitudeOffset;
   return new google.maps.LatLng(latLng.lat(), newLng);
 }
-/* [END maps_ui_kit_place_details_event] */
 
-declare global {
-  interface Window {
-    initMap: () => void;
-  }
-}
-window.initMap = initMap;
+initMap();
 /* [END maps_ui_kit_place_details] */
-export {};

--- a/samples/ui-kit-place-search-text/index.html
+++ b/samples/ui-kit-place-search-text/index.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <!--[START maps_ui_kit_place_search_text_map] -->
-    <gmp-map center="-37.813,144.963" zoom="10" map-id="DEMO_MAP_ID">
+    <gmp-map center="37.395641,-122.077627" zoom="10" map-id="DEMO_MAP_ID">
       <div class="overlay" slot="control-inline-start-block-start">
         <div class="list-container">
           <gmp-place-list selectable></gmp-place-list>
@@ -23,10 +23,8 @@
       <gmp-place-details size="large"></gmp-place-details>
     </gmp-map>
     <!--[END maps_ui_kit_place_search_text_map] -->
-    <script
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8&libraries=maps&callback=initMap&v=alpha"
-      defer
-    ></script>
+    <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
+        ({key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "alpha"});</script>
   </body>
 </html>
 <!--[END maps_ui_kit_place_search_text] -->

--- a/samples/ui-kit-place-search-text/index.ts
+++ b/samples/ui-kit-place-search-text/index.ts
@@ -32,7 +32,7 @@ async function initMap(): Promise<void>  {
         clickableIcons: false,
     });
 
-    searchByTextRequest('tacos near me');
+    searchByTextRequest('tacos in Mountain View');
 }
 /* [END maps_ui_kit_place_search_text_init_map] */
 
@@ -100,11 +100,5 @@ function offsetLatLngRight(latLng, longitudeOffset) {
     return new google.maps.LatLng(latLng.lat, newLng);
 }
 
-declare global {
-    interface Window {
-      initMap: () => void;
-    }
-  }
-  window.initMap = initMap;
+initMap();
 /* [END maps_ui_kit_place_search_text] */
-export{};

--- a/samples/ui-kit-place-search-text/tsconfig.json
+++ b/samples/ui-kit-place-search-text/tsconfig.json
@@ -12,6 +12,6 @@
         "dom.iterable"
       ],
       "moduleResolution": "Node",
-      "jsx": "preserve"
+      "jsx": "preserve",
     }
   }

--- a/samples/ui-kit-place-search/index.html
+++ b/samples/ui-kit-place-search/index.html
@@ -33,10 +33,8 @@
       <gmp-place-details size="large"></gmp-place-details>
     </gmp-map>
     <!--[END maps_ui_kit_place_search_map] -->
-    <script
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8&libraries=maps&callback=initMap&v=alpha"
-      defer
-    ></script>
+    <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
+        ({key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "alpha"});</script>
   </body>
 </html>
 <!--[END maps_ui_kit_place_search] -->

--- a/samples/ui-kit-place-search/index.ts
+++ b/samples/ui-kit-place-search/index.ts
@@ -124,11 +124,5 @@ async function findCurrentLocation(){
 
 }
 
-declare global {
-    interface Window {
-      initMap: () => void;
-    }
-  }
-  window.initMap = initMap;
+initMap();
 /* [END maps_ui_kit_place_search] */
-export{};


### PR DESCRIPTION
TSC has started stripping the final region tag in JS output. This happened primarily wherever `export { }` was in use. This change updates affected examples either by removing the export statement where superfluous (yes that happened), or by refactoring the affected example to use the new bootloader to remove the need to use `export { }`.