### PR TITLE
fix: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ gha-creds-*.json
 samples/deckgl-editable-geojson
 samples/deckgl-kml-raster
 
-/dist/
 .env


### PR DESCRIPTION
Removes "/dist/" from .gitignore, as that BREAKS the dist output build process. In future please do not add dist to .gitignore.