### PR TITLE
fix: Changes email address of googlemaps-bot to use google.com.

### DIFF
--- a/.github/workflows/approve-merge.yml
+++ b/.github/workflows/approve-merge.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: github.event.pull_request.user.login == 'googlemaps-bot[bot]' && github.event.pull_request.head.ref == 'temp-build-branch' # change here
+    if: github.event.pull_request.user.login == 'googlemaps-bot[bot]' && github.event.pull_request.head.ref == 'temp-build-branch'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set Git Identity
         run: |
           git config --global user.name 'googlemaps-bot'
-          git config --global user.email 'googlemaps-bot@users.noreply.github.com'
+          git config --global user.email 'googlemaps-bot@google.com'
 
       - name: Create Pull Request
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set Git Identity
         run: |
           git config --global user.name 'googlemaps-bot'
-          git config --global user.email 'googlemaps-bot@users.noreply.github.com'
+          git config --global user.email 'googlemaps-bot@google.com'
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
This PR attempts to fix the issue where googlemaps-bot is missing CLA, by updating the email address to use google.com. Every place internally lists 'googlemaps-bot@google.com', but the config files were using 'googlemaps-bot@users.noreply.github.com'

A review of previous changes shows that #223 was where the first "chore" was attempted: it failed! So nothing changed, it has never worked.