### PR TITLE
fix: restore release workflow but leave testing in place

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,9 @@ jobs:
           echo "Building affected workspaces:"
           for workspace in "${AFFECTED_WORKSPACES_ARRAY[@]}"; do
             echo "  - samples/$workspace"
-            npm run build --workspace=samples/$workspace
           done
 
-      - name: Generate index
-        run: npm run generate-index
+      - run: npm run build-all
 
       - uses: google-github-actions/auth@v1
         with:


### PR DESCRIPTION
Restores build-all, and removes build statement from "affected projects" stanza; script will require additional testing :-)