### PR TITLE
fix: Removes path-ignore statements

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,9 +24,6 @@ on:
       - 'e2e/samples.spec.ts'
       - 'playwright.config.ts'
       - 'package.json'
-    paths-ignore:
-      - '.github/dependabot.yml'
-      - 'package-lock.json'
   push:
     branches:
       - main
@@ -35,9 +32,6 @@ on:
       - 'e2e/samples.spec.ts'
       - 'playwright.config.ts'
       - 'package.json'
-    paths-ignore:
-      - '.github/dependabot.yml'
-      - 'package-lock.json'
   schedule:
     - cron: "0 12 * * *"
 


### PR DESCRIPTION
Since you can only have 'paths' OR 'paths-ignore', we'll remove 'paths-ignore' from the pull_request and push events.

(Invalid workflow file you may only define one of `paths` and `paths-ignore` for a single event)