### PR TITLE
fix: Minor fixes to make test workflow work again.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Run All Playwright Tests
         run: npx playwright test e2e/samples.spec.ts
         env:
+          # Pass the correct base reference for find-changes.sh
+          GIT_BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || 'origin/main' }}
           CI: true
 
       - name: Upload Test Report Artifact

--- a/samples/find-changes.sh
+++ b/samples/find-changes.sh
@@ -62,6 +62,17 @@ if [ -z "$UNIQUE_CHANGED_WORKSPACES" ]; then
   exit 0
 fi
 
+# --- Post-process UNIQUE_CHANGED_WORKSPACES to remove any '-e ' prefix ---
+# This addresses an observed issue where folder names might be unexpectedly prefixed.
+CLEANED_WORKSPACES_BUFFER=""
+while IFS= read -r line; do
+  if [ -n "$line" ]; then # Process only non-empty lines
+    cleaned_line=$(echo "$line" | sed 's/^-e[[:space:]]*//') # Match -e followed by zero or more spaces
+    CLEANED_WORKSPACES_BUFFER+="$cleaned_line\n"
+  fi
+done <<< "$UNIQUE_CHANGED_WORKSPACES"
+UNIQUE_CHANGED_WORKSPACES=$(echo -e "$CLEANED_WORKSPACES_BUFFER" | sed '/^$/d') # Remove any trailing empty line
+
 echo "Changed (added or modified) subfolders in '$PROJECTS_ROOT_DIR':"
 echo "$UNIQUE_CHANGED_WORKSPACES"
 


### PR DESCRIPTION
Addresses some inconsistent behavior:
* Changes some commands to use 'bash' instead of 'sh'.
* Adds code to pass base ref for find-changes.sh.
* Adds code to clean '-e' prefix if it appears (depends on where/how script is run).

After fixing the test file I noticed that our tests were no longer working. Further investigation revealed that the output from the find-changes.sh script was including the '-e' flag from the echo command. These changes should ensure more consistent behavior.