### PR TITLE
fix: Update playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -148,9 +148,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright # Default Playwright cache path
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('playwright.config.ts') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}-${{ hashFiles('playwright.config.ts') }}
           restore-keys: |
-            ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}- # Fallback for lock file changes
+            ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}- # Fallback for lock file changes
             ${{ runner.os }}-playwright- # Broader fallback
 
       - name: Install dependencies


### PR DESCRIPTION
Changes Playwright browser caching to use the root lockfile (package-lock.json), which should keep browsers cached and avoid lengthy browser reinstall (the cache refreshes when the lockfile changes, root lockfile changes less frequently but project lockfiles change every time).