### PR TITLE
fix: Update playwright.yml to use npm install

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -81,7 +81,7 @@ jobs:
             ${{ runner.os }}-playwright- # Broader fallback
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
Changes `run: npm ci` to `run: npm install`. Using `npm ci` was a bad choice since it doesn't resolve the workspace (introducing new samples results in a change to package.json; npm install ensures that package-lock.json gets updated to be in sync).