### PR TITLE
Remove 'branches' from pull_request block

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,8 +16,6 @@ name: Playwright Tests
 
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, synchronize, edited]
     paths:
       - 'samples/**'


### PR DESCRIPTION
With this change, tests will now be run on any branch that's opened, sync'ed or edited (with the defined paths).