### PR TITLE
fix: Adds browsers path

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,6 +77,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}- # Fallback for lock file changes
             ${{ runner.os }}-playwright- # Broader fallback
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The Playwright cache is not being observed or enforced, as a result the installation steps run every time. This change should help Playwright to correctly recognize the cache and avoid repeated installation.

From my compulsory collaborator:
the PLAYWRIGHT_BROWSERS_PATH environment variable tells Playwright where to look for existing browsers. By setting this variable to match your cache path, you ensure that Playwright checks the cache before attempting a download.