### PR TITLE
fix: Updates how BASE_REF works

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,11 +50,16 @@ jobs:
           fetch-depth: 0
           lfs: true
 
+      - name: Set BASE_REF for PRs
+        id: set_base_ref
+        if: github.event_name == 'pull_request'
+        run: echo "base_ref=origin/${{ github.base_ref }}" >> $GITHUB_OUTPUT
+
       - name: Get Affected Workspaces
         id: get_workspaces
         # For PRs, compare against the origin's version of the base branch.
         # For pushes, compare against the commit before the push.
-        run: bash samples/find-changes.sh ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
+        run: bash samples/find-changes.sh ${{ steps.set_base_ref.outputs.base_ref || github.event.before }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
From our digital overlord:

We've added a new step, "Set BASE_REF for PRs," that runs only for pull requests. It sets an output variable base_ref to origin/{0}, which should be the correct base reference in that context. In the "Get Affected Workspaces" step, we now use this output variable (if it exists) as the argument to find-changes.sh. If the workflow is triggered by a push (or anything other than a pull request), the set_base_ref step will be skipped, and the condition will evaluate to github.event.before (the same behavior as in your release.yml workflow). This approach ensures that find-changes.sh always receives a consistent and accurate base reference, making the process more reliable and easier to understand.