### PR TITLE
fix: Updates playwright conditional

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,16 +50,20 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Set BASE_REF for PRs
+      - name: Set BASE_REF
         id: set_base_ref
-        if: github.event_name == 'pull_request'
-        run: echo "base_ref=origin/${{ github.base_ref }}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base_ref=origin/${{ github.base_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "base_ref=${{ github.event.before }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get Affected Workspaces
         id: get_workspaces
         # For PRs, compare against the origin's version of the base branch.
         # For pushes, compare against the commit before the push.
-        run: bash samples/find-changes.sh ${{ steps.set_base_ref.outputs.base_ref || github.event.before }}
+        run: bash samples/find-changes.sh ${{ steps.set_base_ref.outputs.base_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Gemini sayeth:
Unified Set BASE_REF Step:

The "Set BASE_REF for PRs" step has been renamed to the more general "Set BASE_REF". The if condition is now inside the run block, using a shell if statement to determine the correct base_ref value based on github.event_name. This makes the logic clearer and handles both pull_request and other events (like push) consistently. Consistent find-changes.sh Call:

The "Get Affected Workspaces" step now always calls find-changes.sh with a BASE_REF argument: bash samples/find-changes.sh ${{ steps.set_base_ref.outputs.base_ref }}. This argument will always be populated thanks to the Set BASE_REF step.