### PR TITLE
fix: Removes GIT_BASE_REF line

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -56,8 +56,6 @@ jobs:
           BASE_REF=$([ "${{ github.event_name }}" == "pull_request" ] && echo "origin/${{ github.base_ref }}" || echo "${{ github.event.before }}")
           echo "Using BASE_REF: $BASE_REF"  # Optional: for debugging
           bash samples/find-changes.sh "$BASE_REF"
-        env:
-          GIT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Removes definition sof GIT_BASE_REF. Gemini says the following jive:

By removing the potentially conflicting GIT_BASE_REF environment variable, we simplify the workflow and ensure that find-changes.sh consistently uses the BASE_REF value we're explicitly providing. This should help us determine if the root cause of the empty affected_workspaces is related to an incorrect base reference.

So this is more of a debugging step.