### PR TITLE
fix: Replaces set_gh_output with direct assignment

### DIFF
--- a/samples/find-changes.sh
+++ b/samples/find-changes.sh
@@ -77,4 +77,5 @@ echo "Changed (added or modified) subfolders in '$PROJECTS_ROOT_DIR':"
 echo "$UNIQUE_CHANGED_WORKSPACES"
 
 # Set the output variable for GitHub Actions
-set_gh_output "changed_workspaces" "$UNIQUE_CHANGED_WORKSPACES"
+# set_gh_output "changed_workspaces" "$UNIQUE_CHANGED_WORKSPACES"
+echo "changed_workspaces=$UNIQUE_CHANGED_WORKSPACES" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Taking a different tack here, this is slightly cleaner than the method call. I'm gambling that some subtlety is in play, but the fact that this script already seems to generate valid output at one stage...well hey.