### PR TITLE
fix: adds newline before start region tag

### DIFF
--- a/samples/deckgl-heatmap/index.ts
+++ b/samples/deckgl-heatmap/index.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 /* [START maps_deckgl_heatmap] */
 // Declare global namespace for Deck.gl to satisfy TypeScript compiler
 declare namespace deck {


### PR DESCRIPTION
region tag is being stripped from output. This is a "hail Mary" to see if adding a space prevents that.