### PR TITLE
fix: Adds linebreak to prevent region tag from being stripped.

### DIFF
--- a/samples/deckgl-heatmap/index.ts
+++ b/samples/deckgl-heatmap/index.ts
@@ -3,8 +3,8 @@
  * Copyright 2025 Google LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 /* [START maps_deckgl_heatmap] */
+
 // Declare global namespace for Deck.gl to satisfy TypeScript compiler
 declare namespace deck {
   class HeatmapLayer {

--- a/samples/deckgl-kml/index.ts
+++ b/samples/deckgl-kml/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* [START maps_deckgl_kml] */
+
 // Import necessary loader
 import { KMLLoader } from '@loaders.gl/kml';
 

--- a/samples/deckgl-polygon/index.ts
+++ b/samples/deckgl-polygon/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* [START maps_deckgl_polygon] */
+
 // Declare global namespace for Deck.gl to satisfy TypeScript compiler
 declare namespace deck {
   class PolygonLayer {
@@ -40,7 +41,6 @@ async function initMap(): Promise<void> {
       progressDiv?.remove(); // Use optional chaining in case progressDiv is null
     };
   }
-
 
   // The location for the map center.
   const position = {lat: 37.752954624496304, lng:-122.44754059928648}; // Using the center from original deckgl-polygon.js


### PR DESCRIPTION
I noticed that in a couple of the deckgl KML demos, the region tag was weirdly being stripped from only certain JS outputs. The process scripts for these only copy, they don't do any manipulation.

THE FIX: Adding a line break after the opening region tag in TS files seems to help; some of the TS code is being stripped (`declare namespace deck {...`), but I think this is actually expected since all of the demos work just fine on hosting.

Change-Id: I8dabf2932d5dab5b062f8ddb19c607d310c6565e