### PR TITLE
fix: Trigger nearby search after map load

### DIFF
--- a/samples/place-nearby-search/index.ts
+++ b/samples/place-nearby-search/index.ts
@@ -29,8 +29,10 @@ async function initMap() {
 
     infoWindow = new InfoWindow();
 
-    // Kick off an initial search.
-    nearbySearch();
+    // Kick off an initial search once map has loaded.
+    google.maps.event.addListenerOnce(innerMap, 'idle', () => {
+        nearbySearch();
+    });
 }
 
 async function nearbySearch() {


### PR DESCRIPTION
Modify the initial search to trigger after the map has loaded, by waiting for idle. Now the map loads consistently every time (no race condition).