### PR TITLE
Remove strict mode declaration from index.ts

### DIFF
--- a/samples/routes-get-alternatives/index.ts
+++ b/samples/routes-get-alternatives/index.ts
@@ -1,4 +1,3 @@
-"use strict";
 /*
  * @license
  * Copyright 2025 Google LLC. All Rights Reserved.


### PR DESCRIPTION
It was leftover from some copy and pasting, and has the side effect of causing the TSC to strip the closing region comment tag, which we need!!