### PR TITLE
fix: Modify docs.sh to conditionally copy public folder

### DIFF
--- a/samples/docs.sh
+++ b/samples/docs.sh
@@ -28,4 +28,6 @@ cp "${SCRIPT_DIR}/${NAME}/index.html" "${DOCS_DIR}/index.html"
 cp "${SCRIPT_DIR}/${NAME}/style.css" "${DOCS_DIR}/style.css"
 
 # Copy the data folder if one is found.
-# [ -d "public" ] && cp -r public/* "${DOCS_DIR}/"
+if [ -d "public" ] && [ "$(ls -A public)" ]; then
+  cp -r public/* "${DOCS_DIR}/"
+fi


### PR DESCRIPTION
This fixes an error. Updated the script to copy the 'public' folder only if it contains files.