### PR TITLE
refactor: Replace rounds with repeatCount in flyCameraAround calls

### DIFF
--- a/samples/3d-camera-to-around/index.ts
+++ b/samples/3d-camera-to-around/index.ts
@@ -39,7 +39,7 @@ async function init() {
             // Length of time to fly to the location.
             durationMillis: 50000,
             // Number of rotations to make in the specified time.
-            rounds: 1
+            repeatCount: 1
         });
     }, {once: true}); // Stop animation after flying around.
 

--- a/samples/3d-marker-click-event/index.ts
+++ b/samples/3d-marker-click-event/index.ts
@@ -33,7 +33,7 @@ async function initMap() {
         map.flyCameraAround({
             camera: originalCamera,
             durationMillis: 50000,
-            rounds: 1
+            repeatCount: 1
         });
     });
 


### PR DESCRIPTION
## Summary
- Updated `flyCameraAround` calls in 3D samples to use `repeatCount` parameter instead of `rounds`
- Affects `samples/3d-camera-to-around/index.ts` and `samples/3d-marker-click-event/index.ts`