### PR TITLE
Fix comment formatting for boundaries click event

### DIFF
--- a/samples/boundaries-click/index.ts
+++ b/samples/boundaries-click/index.ts
@@ -150,4 +150,4 @@ function updateInfoWindow(content, center) {
 }
 
 initMap();
-//  [END maps_boundaries_click_event]
+// [END maps_boundaries_click_event]


### PR DESCRIPTION
There was an extra space in a region tag, preventing it from being stripped for JSFiddle output.