### PR TITLE
Rename CSS selector from #map to .gmp-map

### DIFF
--- a/samples/place-autocomplete-data-session/style.css
+++ b/samples/place-autocomplete-data-session/style.css
@@ -8,7 +8,7 @@
  * Always set the map height explicitly to define the size of the div element
  * that contains the map. 
  */
-#map {
+gmp-map {
   height: 100%;
 }
 


### PR DESCRIPTION
This step was overlooked in the previous revision.