### PR TITLE
feat: Updates jsfiddle script to replace asset paths.

### DIFF
--- a/dist/samples/place-autocomplete-data-simple/dist/index.html
+++ b/dist/samples/place-autocomplete-data-simple/dist/index.html
@@ -12,8 +12,8 @@
     <!-- prettier-ignore -->
     <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
         ({key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "weekly"});</script>
-    <script type="module" crossorigin src="./assets/index-By55CHJw.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-DWepjxzn.css">
+    <script type="module" crossorigin src="./assets/index-C9lgJWC0.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BBH1vU_3.css">
   </head>
   <body>
     <!-- [START maps_place_autocomplete_data_simple_html] -->

--- a/dist/samples/place-autocomplete-data-simple/jsfiddle/demo.html
+++ b/dist/samples/place-autocomplete-data-simple/jsfiddle/demo.html
@@ -22,7 +22,7 @@
     <p><span id="prediction"></span></p>
     <img
       class="powered-by-google"
-      src="./powered_by_google_on_white.png"
+      src="https://maps-docs-team.web.app/samples/place-autocomplete-data-simple/dist/powered_by_google_on_white.png"
       alt="Powered by Google"
     />
     


### PR DESCRIPTION
JSFiddle cannot host external assets (PNG, JSON, etc.). This PR updates the JSFiddle CI/CD script to replace local asset paths with the corresponding hosting path. This ensures that JSFiddle can see the needed asset files. In this system all assets are stored with their projects; therefore they are hosted by default. This PR takes advantage of that, and ensures that all asset URLs are valid when loaded in JSFiddle.