### PR TITLE
feat: global tsconfig update.

### DIFF
--- a/samples/3d-accessibility-features/tsconfig.json
+++ b/samples/3d-accessibility-features/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-camera-boundary/tsconfig.json
+++ b/samples/3d-camera-boundary/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-camera-center/tsconfig.json
+++ b/samples/3d-camera-center/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-camera-to-around/tsconfig.json
+++ b/samples/3d-camera-to-around/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-clamp-mode/tsconfig.json
+++ b/samples/3d-clamp-mode/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-coverage-map/tsconfig.json
+++ b/samples/3d-coverage-map/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-label-toggle/tsconfig.json
+++ b/samples/3d-label-toggle/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-localization/tsconfig.json
+++ b/samples/3d-localization/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-map-45-degree/tsconfig.json
+++ b/samples/3d-map-45-degree/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-map-roadmap/tsconfig.json
+++ b/samples/3d-map-roadmap/tsconfig.json
@@ -1,11 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
     "strict": true,
     "noImplicitAny": false,
     "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-map-styling/tsconfig.json
+++ b/samples/3d-map-styling/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-click-event/tsconfig.json
+++ b/samples/3d-marker-click-event/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-collision-behavior/tsconfig.json
+++ b/samples/3d-marker-collision-behavior/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-customization/tsconfig.json
+++ b/samples/3d-marker-customization/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-graphics/tsconfig.json
+++ b/samples/3d-marker-graphics/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-html/tsconfig.json
+++ b/samples/3d-marker-html/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-marker-interactive/tsconfig.json
+++ b/samples/3d-marker-interactive/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-mesh-flatten/tsconfig.json
+++ b/samples/3d-mesh-flatten/tsconfig.json
@@ -1,11 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
     "strict": true,
     "noImplicitAny": false,
     "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-model-interactive/tsconfig.json
+++ b/samples/3d-model-interactive/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-model/tsconfig.json
+++ b/samples/3d-model/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-places-autocomplete/tsconfig.json
+++ b/samples/3d-places-autocomplete/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-places/tsconfig.json
+++ b/samples/3d-places/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polygon-click-event/tsconfig.json
+++ b/samples/3d-polygon-click-event/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polygon-extruded-hole/tsconfig.json
+++ b/samples/3d-polygon-extruded-hole/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polygon/tsconfig.json
+++ b/samples/3d-polygon/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polyline-click-event/tsconfig.json
+++ b/samples/3d-polyline-click-event/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polyline-extruded/tsconfig.json
+++ b/samples/3d-polyline-extruded/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-polyline/tsconfig.json
+++ b/samples/3d-polyline/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-popover-location/tsconfig.json
+++ b/samples/3d-popover-location/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-popover-marker/tsconfig.json
+++ b/samples/3d-popover-marker/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-simple-map-declarative/tsconfig.json
+++ b/samples/3d-simple-map-declarative/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-simple-map/tsconfig.json
+++ b/samples/3d-simple-map/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/3d-simple-marker/tsconfig.json
+++ b/samples/3d-simple-marker/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/add-map/tsconfig.json
+++ b/samples/add-map/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/address-validation/tsconfig.json
+++ b/samples/address-validation/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/advanced-markers-accessibility/tsconfig.json
+++ b/samples/advanced-markers-accessibility/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-altitude/tsconfig.json
+++ b/samples/advanced-markers-altitude/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-animation/tsconfig.json
+++ b/samples/advanced-markers-animation/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-basic-style/tsconfig.json
+++ b/samples/advanced-markers-basic-style/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-collision/tsconfig.json
+++ b/samples/advanced-markers-collision/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-draggable/tsconfig.json
+++ b/samples/advanced-markers-draggable/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-graphics/tsconfig.json
+++ b/samples/advanced-markers-graphics/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-html-simple/tsconfig.json
+++ b/samples/advanced-markers-html-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-html/tsconfig.json
+++ b/samples/advanced-markers-html/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-simple/tsconfig.json
+++ b/samples/advanced-markers-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/advanced-markers-zoom/tsconfig.json
+++ b/samples/advanced-markers-zoom/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/ai-powered-summaries-basic/tsconfig.json
+++ b/samples/ai-powered-summaries-basic/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/ai-powered-summaries/tsconfig.json
+++ b/samples/ai-powered-summaries/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/boundaries-choropleth/tsconfig.json
+++ b/samples/boundaries-choropleth/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/boundaries-click/tsconfig.json
+++ b/samples/boundaries-click/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/boundaries-simple/tsconfig.json
+++ b/samples/boundaries-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/boundaries-text-search/tsconfig.json
+++ b/samples/boundaries-text-search/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/circle-simple/tsconfig.json
+++ b/samples/circle-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-bounds-restriction/tsconfig.json
+++ b/samples/control-bounds-restriction/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-custom-state/tsconfig.json
+++ b/samples/control-custom-state/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-disableUI/tsconfig.json
+++ b/samples/control-disableUI/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-options/tsconfig.json
+++ b/samples/control-options/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-positioning-labels/tsconfig.json
+++ b/samples/control-positioning-labels/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-positioning/tsconfig.json
+++ b/samples/control-positioning/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/control-replacement/tsconfig.json
+++ b/samples/control-replacement/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",

--- a/samples/control-simple/tsconfig.json
+++ b/samples/control-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-datasets-point/tsconfig.json
+++ b/samples/dds-datasets-point/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-datasets-polygon-click/tsconfig.json
+++ b/samples/dds-datasets-polygon-click/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-datasets-polygon-colors/tsconfig.json
+++ b/samples/dds-datasets-polygon-colors/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-datasets-polygon/tsconfig.json
+++ b/samples/dds-datasets-polygon/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-datasets-polyline/tsconfig.json
+++ b/samples/dds-datasets-polyline/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/dds-region-viewer/tsconfig.json
+++ b/samples/dds-region-viewer/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve",
     "resolveJsonModule": true,
   }

--- a/samples/deckgl-arclayer/tsconfig.json
+++ b/samples/deckgl-arclayer/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve",
     "skipLibCheck": true
   }

--- a/samples/deckgl-heatmap/tsconfig.json
+++ b/samples/deckgl-heatmap/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/deckgl-kml-updated/tsconfig.json
+++ b/samples/deckgl-kml-updated/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve",
       "esModuleInterop": true
     }

--- a/samples/deckgl-kml/tsconfig.json
+++ b/samples/deckgl-kml/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve",
       "esModuleInterop": true
     }

--- a/samples/deckgl-points/tsconfig.json
+++ b/samples/deckgl-points/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -12,7 +13,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/deckgl-polygon/tsconfig.json
+++ b/samples/deckgl-polygon/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/deckgl-tripslayer/tsconfig.json
+++ b/samples/deckgl-tripslayer/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "skipLibCheck": true,
     "module": "esnext",
@@ -12,7 +13,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/event-arguments/tsconfig.json
+++ b/samples/event-arguments/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/event-click-latlng/tsconfig.json
+++ b/samples/event-click-latlng/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/event-closure/tsconfig.json
+++ b/samples/event-closure/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/event-poi/tsconfig.json
+++ b/samples/event-poi/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/event-simple/tsconfig.json
+++ b/samples/event-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/geocoding-reverse/tsconfig.json
+++ b/samples/geocoding-reverse/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/geocoding-simple/tsconfig.json
+++ b/samples/geocoding-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/hiding-features/tsconfig.json
+++ b/samples/hiding-features/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/js-api-loader-map/tsconfig.json
+++ b/samples/js-api-loader-map/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/layer-data-event/tsconfig.json
+++ b/samples/layer-data-event/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/layer-data-quakes-red/tsconfig.json
+++ b/samples/layer-data-quakes-red/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/layer-data-quakes-simple/tsconfig.json
+++ b/samples/layer-data-quakes-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/layer-data-simple/tsconfig.json
+++ b/samples/layer-data-simple/tsconfig.json
@@ -1,11 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
     "strict": true,
     "noImplicitAny": false,
     "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/layer-data-style/tsconfig.json
+++ b/samples/layer-data-style/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/map-events/tsconfig.json
+++ b/samples/map-events/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/map-projection-simple/tsconfig.json
+++ b/samples/map-projection-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/map-simple/tsconfig.json
+++ b/samples/map-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-autocomplete-basic-map/tsconfig.json
+++ b/samples/place-autocomplete-basic-map/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-autocomplete-data-session/tsconfig.json
+++ b/samples/place-autocomplete-data-session/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-autocomplete-data-simple/tsconfig.json
+++ b/samples/place-autocomplete-data-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-autocomplete-element/tsconfig.json
+++ b/samples/place-autocomplete-element/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-autocomplete-map/tsconfig.json
+++ b/samples/place-autocomplete-map/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-class/tsconfig.json
+++ b/samples/place-class/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-nearby-search/tsconfig.json
+++ b/samples/place-nearby-search/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-photos/tsconfig.json
+++ b/samples/place-photos/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/place-reviews/tsconfig.json
+++ b/samples/place-reviews/tsconfig.json
@@ -1,11 +1,12 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
         "module": "esnext",
         "target": "esnext",
         "strict": true,
         "noImplicitAny": false,
         "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-        "moduleResolution": "Node",
+        "moduleResolution": "bundler",
         "jsx": "preserve"
     }
 }

--- a/samples/place-text-search/tsconfig.json
+++ b/samples/place-text-search/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/places-autocomplete-addressform/tsconfig.json
+++ b/samples/places-autocomplete-addressform/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/places-placeid-finder/tsconfig.json
+++ b/samples/places-placeid-finder/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/polyline-complex/tsconfig.json
+++ b/samples/polyline-complex/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/polyline-remove/tsconfig.json
+++ b/samples/polyline-remove/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/polyline-simple/tsconfig.json
+++ b/samples/polyline-simple/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -14,11 +14,11 @@
       ],
       "moduleResolution": "bundler",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",
-        "node",
-        "google.maps"
+        "node"
       ]
     }
   }

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "types": [

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -17,7 +17,8 @@
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     }
   }

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -18,7 +18,8 @@
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     }
   }

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -19,7 +19,8 @@
       "verbatimModuleSyntax": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     },
   }

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -18,7 +18,8 @@
       "verbatimModuleSyntax": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     },
   }

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "verbatimModuleSyntax": true,

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -14,6 +14,7 @@
       ],
       "moduleResolution": "bundler",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "verbatimModuleSyntax": true,
       "types": [

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -19,8 +19,7 @@
       "verbatimModuleSyntax": true,
       "types": [
         "vite/client",
-        "node",
-        "google.maps"
+        "node"
       ]
     },
   }

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/react-ui-kit-place-details-latlng/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng/tsconfig.json
@@ -14,6 +14,7 @@
       ],
       "moduleResolution": "bundler",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",

--- a/samples/react-ui-kit-place-details-latlng/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "types": [

--- a/samples/react-ui-kit-place-details-latlng/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng/tsconfig.json
@@ -18,7 +18,8 @@
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     }
   }

--- a/samples/react-ui-kit-place-details-latlng/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/react-ui-kit-place-details/tsconfig.json
+++ b/samples/react-ui-kit-place-details/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "types": [

--- a/samples/react-ui-kit-place-details/tsconfig.json
+++ b/samples/react-ui-kit-place-details/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
       "module": "esnext",
       "target": "esnext",

--- a/samples/react-ui-kit-place-details/tsconfig.json
+++ b/samples/react-ui-kit-place-details/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/react-ui-kit-place-details/tsconfig.json
+++ b/samples/react-ui-kit-place-details/tsconfig.json
@@ -14,10 +14,12 @@
       ],
       "moduleResolution": "bundler",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ],
       "removeComments": false,
     }

--- a/samples/react-ui-kit-search-nearby/tsconfig.json
+++ b/samples/react-ui-kit-search-nearby/tsconfig.json
@@ -14,11 +14,13 @@
       ],
       "moduleResolution": "bundler",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "verbatimModuleSyntax": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     }
   }

--- a/samples/react-ui-kit-search-nearby/tsconfig.json
+++ b/samples/react-ui-kit-search-nearby/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "verbatimModuleSyntax": true,

--- a/samples/react-ui-kit-search-nearby/tsconfig.json
+++ b/samples/react-ui-kit-search-nearby/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/react-ui-kit-search-text/tsconfig.json
+++ b/samples/react-ui-kit-search-text/tsconfig.json
@@ -14,11 +14,13 @@
       ],
       "moduleResolution": "node",
       "jsx": "react-jsx",
+      "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,
       "verbatimModuleSyntax": true,
       "types": [
         "vite/client",
-        "node"
+        "node",
+        "google.maps"
       ]
     }
   }

--- a/samples/react-ui-kit-search-text/tsconfig.json
+++ b/samples/react-ui-kit-search-text/tsconfig.json
@@ -12,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "jsx": "react-jsx",
       "skipLibCheck": true,
       "allowSyntheticDefaultImports": true,

--- a/samples/react-ui-kit-search-text/tsconfig.json
+++ b/samples/react-ui-kit-search-text/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,

--- a/samples/routes-compute-routes/tsconfig.json
+++ b/samples/routes-compute-routes/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/routes-get-alternatives/tsconfig.json
+++ b/samples/routes-get-alternatives/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/routes-get-directions-panel/tsconfig.json
+++ b/samples/routes-get-directions-panel/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/routes-get-directions/tsconfig.json
+++ b/samples/routes-get-directions/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/routes-markers/tsconfig.json
+++ b/samples/routes-markers/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/routes-route-matrix/tsconfig.json
+++ b/samples/routes-route-matrix/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/streetview-overlays/tsconfig.json
+++ b/samples/streetview-overlays/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/test-example/tsconfig.json
+++ b/samples/test-example/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/ui-kit-place-details-compact/tsconfig.json
+++ b/samples/ui-kit-place-details-compact/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/ui-kit-place-details/tsconfig.json
+++ b/samples/ui-kit-place-details/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/ui-kit-place-search-nearby/tsconfig.json
+++ b/samples/ui-kit-place-search-nearby/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve"
     }
   }

--- a/samples/ui-kit-place-search-text/tsconfig.json
+++ b/samples/ui-kit-place-search-text/tsconfig.json
@@ -1,5 +1,6 @@
 {
-    "compilerOptions": {
+    "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
       "module": "esnext",
       "target": "esnext",
       "strict": true,
@@ -11,7 +12,7 @@
         "dom",
         "dom.iterable"
       ],
-      "moduleResolution": "Node",
+      "moduleResolution": "bundler",
       "jsx": "preserve",
     }
   }

--- a/samples/weather-api-current-compact/tsconfig.json
+++ b/samples/weather-api-current-compact/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve",
     "types": ["@types/google.maps"]
   }

--- a/samples/web-components-map/tsconfig.json
+++ b/samples/web-components-map/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/samples/web-components-markers/tsconfig.json
+++ b/samples/web-components-markers/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
@@ -11,7 +12,7 @@
       "dom",
       "dom.iterable"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "preserve"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["google.maps"]
+  }
+}


### PR DESCRIPTION
There are two issues at play here, not sure whether they are related:
* TS (or something) changed and ambient type declarations began failing. I noticed when `google` stopped resolving in the editor for ALL projects. Weird.
* The "Node" module resolution option is deprecated. This warning also cropped up this morning, and also has the side effect of breaking the build for each project.

These changes likely came along with the Node update to version 6 from last month, and I suspect it's taken this long for me to manage to get the dependency graph to redraw. Today was the day.

This PR does the following things:
* Adds a root shared TypeScript config (e.g. tsconfig.base.json) that declares the Google Maps ambient typings.
* Updates every sample samples/*/tsconfig.json to extend the root config.
* Updates all moduleResolution to "bundled" ("node" is deprecated).
* Adds  "skipLibCheck": true, to select projects (React UI Kit ones had some upstream conflicts that this will safely hide).
* Gives me back the minutes of my life spent doing this (not sure if it can, but I'll ask anyway).