### PR TITLE
feat: Refactor and optimize tsconfigs.

### DIFF
--- a/samples/3d-accessibility-features/tsconfig.json
+++ b/samples/3d-accessibility-features/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-camera-boundary/tsconfig.json
+++ b/samples/3d-camera-boundary/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-camera-center/tsconfig.json
+++ b/samples/3d-camera-center/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-camera-to-around/tsconfig.json
+++ b/samples/3d-camera-to-around/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-clamp-mode/tsconfig.json
+++ b/samples/3d-clamp-mode/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-coverage-map/tsconfig.json
+++ b/samples/3d-coverage-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-label-toggle/tsconfig.json
+++ b/samples/3d-label-toggle/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-localization/tsconfig.json
+++ b/samples/3d-localization/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-map-45-degree/tsconfig.json
+++ b/samples/3d-map-45-degree/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-map-roadmap/tsconfig.json
+++ b/samples/3d-map-roadmap/tsconfig.json
@@ -1,11 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-map-styling/tsconfig.json
+++ b/samples/3d-map-styling/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-click-event/tsconfig.json
+++ b/samples/3d-marker-click-event/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-collision-behavior/tsconfig.json
+++ b/samples/3d-marker-collision-behavior/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-customization/tsconfig.json
+++ b/samples/3d-marker-customization/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-graphics/tsconfig.json
+++ b/samples/3d-marker-graphics/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-html/tsconfig.json
+++ b/samples/3d-marker-html/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-marker-interactive/tsconfig.json
+++ b/samples/3d-marker-interactive/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-mesh-flatten/tsconfig.json
+++ b/samples/3d-mesh-flatten/tsconfig.json
@@ -1,11 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-model-interactive/tsconfig.json
+++ b/samples/3d-model-interactive/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-model/tsconfig.json
+++ b/samples/3d-model/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-places-autocomplete/tsconfig.json
+++ b/samples/3d-places-autocomplete/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-places/tsconfig.json
+++ b/samples/3d-places/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polygon-click-event/tsconfig.json
+++ b/samples/3d-polygon-click-event/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polygon-extruded-hole/tsconfig.json
+++ b/samples/3d-polygon-extruded-hole/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polygon/tsconfig.json
+++ b/samples/3d-polygon/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polyline-click-event/tsconfig.json
+++ b/samples/3d-polyline-click-event/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polyline-extruded/tsconfig.json
+++ b/samples/3d-polyline-extruded/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-polyline/tsconfig.json
+++ b/samples/3d-polyline/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-popover-location/tsconfig.json
+++ b/samples/3d-popover-location/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-popover-marker/tsconfig.json
+++ b/samples/3d-popover-marker/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-simple-map-declarative/tsconfig.json
+++ b/samples/3d-simple-map-declarative/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-simple-map/tsconfig.json
+++ b/samples/3d-simple-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/3d-simple-marker/tsconfig.json
+++ b/samples/3d-simple-marker/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/add-map/tsconfig.json
+++ b/samples/add-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/address-validation/tsconfig.json
+++ b/samples/address-validation/tsconfig.json
@@ -1,17 +1,12 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "noImplicitAny": false,
+    "strict": false
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/advanced-markers-accessibility/tsconfig.json
+++ b/samples/advanced-markers-accessibility/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-altitude/tsconfig.json
+++ b/samples/advanced-markers-altitude/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-animation/tsconfig.json
+++ b/samples/advanced-markers-animation/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-basic-style/tsconfig.json
+++ b/samples/advanced-markers-basic-style/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-collision/tsconfig.json
+++ b/samples/advanced-markers-collision/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-draggable/tsconfig.json
+++ b/samples/advanced-markers-draggable/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-graphics/tsconfig.json
+++ b/samples/advanced-markers-graphics/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-html-simple/tsconfig.json
+++ b/samples/advanced-markers-html-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-html/tsconfig.json
+++ b/samples/advanced-markers-html/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-simple/tsconfig.json
+++ b/samples/advanced-markers-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/advanced-markers-zoom/tsconfig.json
+++ b/samples/advanced-markers-zoom/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/ai-powered-summaries-basic/tsconfig.json
+++ b/samples/ai-powered-summaries-basic/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/ai-powered-summaries/tsconfig.json
+++ b/samples/ai-powered-summaries/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/boundaries-choropleth/tsconfig.json
+++ b/samples/boundaries-choropleth/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/boundaries-click/tsconfig.json
+++ b/samples/boundaries-click/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/boundaries-simple/tsconfig.json
+++ b/samples/boundaries-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/boundaries-text-search/tsconfig.json
+++ b/samples/boundaries-text-search/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/circle-simple/tsconfig.json
+++ b/samples/circle-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-bounds-restriction/tsconfig.json
+++ b/samples/control-bounds-restriction/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-custom-state/tsconfig.json
+++ b/samples/control-custom-state/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-disableUI/tsconfig.json
+++ b/samples/control-disableUI/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-options/tsconfig.json
+++ b/samples/control-options/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-positioning-labels/tsconfig.json
+++ b/samples/control-positioning-labels/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-positioning/tsconfig.json
+++ b/samples/control-positioning/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-replacement/tsconfig.json
+++ b/samples/control-replacement/tsconfig.json
@@ -1,14 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "types": ["google.maps"]
+    "outDir": "./dist",
+    "rootDir": "."
   },
-  "include": ["./*.ts", "./types/*.d.ts"]
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/control-simple/tsconfig.json
+++ b/samples/control-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-datasets-point/tsconfig.json
+++ b/samples/dds-datasets-point/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-datasets-polygon-click/tsconfig.json
+++ b/samples/dds-datasets-polygon-click/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-datasets-polygon-colors/tsconfig.json
+++ b/samples/dds-datasets-polygon-colors/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-datasets-polygon/tsconfig.json
+++ b/samples/dds-datasets-polygon/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-datasets-polyline/tsconfig.json
+++ b/samples/dds-datasets-polyline/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/dds-region-viewer/tsconfig.json
+++ b/samples/dds-region-viewer/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve",
-    "resolveJsonModule": true,
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/deckgl-arclayer/tsconfig.json
+++ b/samples/deckgl-arclayer/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve",
-    "skipLibCheck": true
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/deckgl-heatmap/tsconfig.json
+++ b/samples/deckgl-heatmap/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/deckgl-kml-updated/tsconfig.json
+++ b/samples/deckgl-kml-updated/tsconfig.json
@@ -1,18 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve",
-      "esModuleInterop": true
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/deckgl-kml/tsconfig.json
+++ b/samples/deckgl-kml/tsconfig.json
@@ -1,18 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve",
-      "esModuleInterop": true
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/deckgl-points/tsconfig.json
+++ b/samples/deckgl-points/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "skipLibCheck": true,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/deckgl-polygon/tsconfig.json
+++ b/samples/deckgl-polygon/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/deckgl-tripslayer/tsconfig.json
+++ b/samples/deckgl-tripslayer/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "skipLibCheck": true,
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2020",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/event-arguments/tsconfig.json
+++ b/samples/event-arguments/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/event-click-latlng/tsconfig.json
+++ b/samples/event-click-latlng/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/event-closure/tsconfig.json
+++ b/samples/event-closure/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/event-poi/tsconfig.json
+++ b/samples/event-poi/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/event-simple/tsconfig.json
+++ b/samples/event-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/geocoding-reverse/tsconfig.json
+++ b/samples/geocoding-reverse/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/geocoding-simple/tsconfig.json
+++ b/samples/geocoding-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/hiding-features/tsconfig.json
+++ b/samples/hiding-features/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/js-api-loader-map/tsconfig.json
+++ b/samples/js-api-loader-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/layer-data-event/tsconfig.json
+++ b/samples/layer-data-event/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/layer-data-quakes-red/tsconfig.json
+++ b/samples/layer-data-quakes-red/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/layer-data-quakes-simple/tsconfig.json
+++ b/samples/layer-data-quakes-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/layer-data-simple/tsconfig.json
+++ b/samples/layer-data-simple/tsconfig.json
@@ -1,11 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/layer-data-style/tsconfig.json
+++ b/samples/layer-data-style/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/map-events/tsconfig.json
+++ b/samples/map-events/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/map-projection-simple/tsconfig.json
+++ b/samples/map-projection-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/map-simple/tsconfig.json
+++ b/samples/map-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-autocomplete-basic-map/tsconfig.json
+++ b/samples/place-autocomplete-basic-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-autocomplete-data-session/tsconfig.json
+++ b/samples/place-autocomplete-data-session/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-autocomplete-data-simple/tsconfig.json
+++ b/samples/place-autocomplete-data-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-autocomplete-element/tsconfig.json
+++ b/samples/place-autocomplete-element/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-autocomplete-map/tsconfig.json
+++ b/samples/place-autocomplete-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-class/tsconfig.json
+++ b/samples/place-class/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-nearby-search/tsconfig.json
+++ b/samples/place-nearby-search/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-photos/tsconfig.json
+++ b/samples/place-photos/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-reviews/tsconfig.json
+++ b/samples/place-reviews/tsconfig.json
@@ -1,11 +1,10 @@
 {
-    "compilerOptions": {
-        "module": "esnext",
-        "target": "esnext",
-        "strict": true,
-        "noImplicitAny": false,
-        "lib": ["es2015", "esnext", "es6", "dom", "dom.iterable"],
-        "moduleResolution": "Node",
-        "jsx": "preserve"
-    }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/place-text-search/tsconfig.json
+++ b/samples/place-text-search/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/places-autocomplete-addressform/tsconfig.json
+++ b/samples/places-autocomplete-addressform/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/places-placeid-finder/tsconfig.json
+++ b/samples/places-placeid-finder/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/polyline-complex/tsconfig.json
+++ b/samples/polyline-complex/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/polyline-remove/tsconfig.json
+++ b/samples/polyline-remove/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/polyline-simple/tsconfig.json
+++ b/samples/polyline-simple/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/react-ui-kit-place-details-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-compact/tsconfig.json
@@ -1,22 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "types": [
-        "vite/client",
-        "node"
-      ]
-    }
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  },
+  "include": [
+    "./src/**/*.ts*",
+  ],
+}

--- a/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/tsconfig.json
@@ -1,23 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "verbatimModuleSyntax": true,
-      "types": [
-        "vite/client",
-        "node"
-      ]
-    },
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  },
+  "include": [
+    "./src/**/*.ts*",
+  ],
+}

--- a/samples/react-ui-kit-place-details-latlng/tsconfig.json
+++ b/samples/react-ui-kit-place-details-latlng/tsconfig.json
@@ -1,22 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "types": [
-        "vite/client",
-        "node"
-      ]
-    }
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  },
+  "include": [
+    "./src/**/*.ts*",
+  ],
+}

--- a/samples/react-ui-kit-place-details/tsconfig.json
+++ b/samples/react-ui-kit-place-details/tsconfig.json
@@ -1,23 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "types": [
-        "vite/client",
-        "node"
-      ],
-      "removeComments": false,
-    }
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx",
+  ]
+}

--- a/samples/react-ui-kit-search-nearby/tsconfig.json
+++ b/samples/react-ui-kit-search-nearby/tsconfig.json
@@ -1,23 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "verbatimModuleSyntax": true,
-      "types": [
-        "vite/client",
-        "node"
-      ]
-    }
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  },
+  "include": [
+    "./src/**/*.ts*",
+  ],
+}

--- a/samples/react-ui-kit-search-text/tsconfig.json
+++ b/samples/react-ui-kit-search-text/tsconfig.json
@@ -1,23 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "node",
-      "jsx": "react-jsx",
-      "allowSyntheticDefaultImports": true,
-      "verbatimModuleSyntax": true,
-      "types": [
-        "vite/client",
-        "node"
-      ]
-    }
-  }
+  "extends": "../../tsconfig.react-base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*.ts*",
+  ],
+}

--- a/samples/routes-compute-routes/tsconfig.json
+++ b/samples/routes-compute-routes/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/routes-get-alternatives/tsconfig.json
+++ b/samples/routes-get-alternatives/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/routes-get-directions-panel/tsconfig.json
+++ b/samples/routes-get-directions-panel/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/routes-get-directions/tsconfig.json
+++ b/samples/routes-get-directions/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/routes-markers/tsconfig.json
+++ b/samples/routes-markers/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/routes-route-matrix/tsconfig.json
+++ b/samples/routes-route-matrix/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/streetview-overlays/tsconfig.json
+++ b/samples/streetview-overlays/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/test-example/tsconfig.json
+++ b/samples/test-example/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/ui-kit-place-details-compact/tsconfig.json
+++ b/samples/ui-kit-place-details-compact/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/ui-kit-place-details/tsconfig.json
+++ b/samples/ui-kit-place-details/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/ui-kit-place-search-nearby/tsconfig.json
+++ b/samples/ui-kit-place-search-nearby/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve"
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/ui-kit-place-search-text/tsconfig.json
+++ b/samples/ui-kit-place-search-text/tsconfig.json
@@ -1,17 +1,10 @@
 {
-    "compilerOptions": {
-      "module": "esnext",
-      "target": "esnext",
-      "strict": true,
-      "noImplicitAny": false,
-      "lib": [
-        "es2015",
-        "esnext",
-        "es6",
-        "dom",
-        "dom.iterable"
-      ],
-      "moduleResolution": "Node",
-      "jsx": "preserve",
-    }
-  }
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}

--- a/samples/weather-api-current-compact/tsconfig.json
+++ b/samples/weather-api-current-compact/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve",
-    "types": ["@types/google.maps"]
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/web-components-map/tsconfig.json
+++ b/samples/web-components-map/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/samples/web-components-markers/tsconfig.json
+++ b/samples/web-components-markers/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "strict": true,
-    "noImplicitAny": false,
-    "lib": [
-      "es2015",
-      "esnext",
-      "es6",
-      "dom",
-      "dom.iterable"
-    ],
-    "moduleResolution": "Node",
-    "jsx": "preserve"
-  }
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["google.maps"],
+  }
+}

--- a/tsconfig.react-base.json
+++ b/tsconfig.react-base.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
-    "types": ["vite/client"]
+    "types": ["vite/client", "google.maps"]
   }
 }

--- a/tsconfig.react-base.json
+++ b/tsconfig.react-base.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowSyntheticDefaultImports": true,
+    "types": ["vite/client"]
+  }
+}


### PR DESCRIPTION
The recent releases of Node.js 26 and TypeScript 6.0 have directly impacted our configuration. These releases each introduced breaking changes. The first symptom was that google was no longer resolving after I rebuilt the dependency graph on my local system. After verifying that this was not due to any error on my part, I was able to confirm that recent updates to TypeScript and Node were responsible. 

This PR addresses the following issues:

* The legacy `moduleResolution: "node"` was officially deprecated.
* In TS 6, the auto-discovery behavior for types was changed, and as a result google.maps ambient declarations were no longer handled the same way (e.g. now we get an error).
* The majority of tsconfig.json files are identical, with React-based projects using a slightly different format.
 
I took this opportunity to fix the underlying issues, optimize tsconfig files to be current, and deduplicate them. I created two new tsconfig root files (one for "vanilla" TS, one for React), and updated the local project tsconfig files to extend it. This will make future maintenance much easier, and result in a more robust and stable repository.

This PR does the following things:

* Creates a new optimized root-level tsconfig for vanilla TS projects.
* Creates a new optimized root-level tsconfig for React projects.
* Updates all tsconfig.json to extend their respective root tsconfigs.