### PR TITLE
feat: Migrates the event-properties sample to js-api-samples.

### DIFF
--- a/samples/event-properties/README.md
+++ b/samples/event-properties/README.md
@@ -1,0 +1,41 @@
+# Google Maps JavaScript Sample
+
+## event-properties
+
+This sample demonstrates how to get properties from event handlers in the Maps JavaScript API.
+
+## Setup
+
+### Before starting run:
+
+`npm i`
+
+### Run an example on a local web server
+
+`cd samples/event-properties`
+`npm start`
+
+### Build an individual example
+
+`cd samples/event-properties`
+`npm run build`
+
+From 'samples':
+
+`npm run build --workspace=event-properties/`
+
+### Build all of the examples.
+
+From 'samples':
+
+`npm run build-all`
+
+### Run lint to check for problems
+
+`cd samples/event-properties`
+`npx eslint index.ts` 
+
+## Feedback
+
+For feedback related to this sample, please open a new issue on
+[GitHub](https://github.com/googlemaps-samples/js-api-samples/issues).

--- a/samples/event-properties/index.html
+++ b/samples/event-properties/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!--
+@license
+Copyright 2026 Google LLC. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<!-- [START maps_event_properties] -->
+<html>
+  <head>
+    <title>Getting Properties With Event Handlers</title>
+
+    <link rel="stylesheet" type="text/css" href="./style.css" />
+    <script type="module" src="./index.js"></script>
+    <!-- prettier-ignore -->
+    <script>(g => { var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary", q = "__ib__", m = document, b = window; b = b[c] || (b[c] = {}); var d = b.maps || (b.maps = {}), r = new Set, e = new URLSearchParams, u = () => h || (h = new Promise(async (f, n) => { await (a = m.createElement("script")); e.set("libraries", [...r] + ""); for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]); e.set("callback", c + ".maps." + q); a.src = `https://maps.${c}apis.com/maps/api/js?` + e; d[q] = f; a.onerror = () => h = n(Error(p + " could not load.")); a.nonce = m.querySelector("script[nonce]")?.nonce || ""; m.head.append(a) })); d[l] ? console.warn(p + " only loads once. Ignoring:", g) : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n)) })
+        ({ key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "weekly" });</script>
+  </head>
+  
+  <body>
+    <gmp-map center="-25.363882,131.044922" zoom="4" map-id="DEMO_MAP_ID"></gmp-map>
+  </body>
+</html>
+<!-- [END maps_event_properties] -->

--- a/samples/event-properties/index.ts
+++ b/samples/event-properties/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// [START maps_event_properties]
+async function initMap() {
+  // Request needed libraries.
+  const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+
+  const mapElement = document.querySelector('gmp-map') as google.maps.MapElement;
+  const innerMap = mapElement.innerMap;
+
+  const infowindow = new google.maps.InfoWindow({
+    content: "Change the zoom level",
+    position: mapElement.center,
+  });
+
+  infowindow.open(innerMap);
+
+  innerMap.addListener("zoom_changed", () => {
+    infowindow.setContent("Zoom: " + innerMap.getZoom()!);
+  });
+}
+
+initMap();
+// [END maps_event_properties]

--- a/samples/event-properties/package.json
+++ b/samples/event-properties/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@js-api-samples/event-properties",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc && bash ../jsfiddle.sh event-properties && bash ../app.sh event-properties && bash ../docs.sh event-properties && npm run build:vite --workspace=. && bash ../dist.sh event-properties",
+    "test": "tsc && npm run build:vite --workspace=.",
+    "start": "tsc && vite build --base './' && vite",
+    "build:vite": "vite build --base './'",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    
+  }
+}

--- a/samples/event-properties/style.css
+++ b/samples/event-properties/style.css
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* [START maps_event_properties] */
+
+/* 
+ * Optional: Makes the sample page fill the window. 
+ */
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+/* [END maps_event_properties] */

--- a/samples/event-properties/tsconfig.json
+++ b/samples/event-properties/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}


### PR DESCRIPTION
This PR does the following things:
* Migrates the event-properties sample to js-api-samples.
* Refactors the sample to use the gmp-map element and inline bootstrap loader.
* Minor cleanup to sample code.

Historical note: This is the first sample migrated by Jetski using a custom skill.