### PR TITLE
feat: Migrates the web-components-events sample to js-api-samples.

### DIFF
--- a/samples/web-components-events/README.md
+++ b/samples/web-components-events/README.md
@@ -1,0 +1,41 @@
+# Google Maps JavaScript Sample
+
+## web-components-events
+
+This sample demonstrates map events using the Maps JavaScript API web components.
+
+## Setup
+
+### Before starting run:
+
+`npm i`
+
+### Run an example on a local web server
+
+`cd samples/web-components-events`
+`npm start`
+
+### Build an individual example
+
+`cd samples/web-components-events`
+`npm run build`
+
+From 'samples':
+
+`npm run build --workspace=web-components-events/`
+
+### Build all of the examples.
+
+From 'samples':
+
+`npm run build-all`
+
+### Run lint to check for problems
+
+`cd samples/web-components-events`
+`npx eslint index.ts` 
+
+## Feedback
+
+For feedback related to this sample, please open a new issue on
+[GitHub](https://github.com/googlemaps-samples/js-api-samples/issues).

--- a/samples/web-components-events/index.html
+++ b/samples/web-components-events/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!--
+@license
+Copyright 2026 Google LLC. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<!-- [START maps_web_components_events] -->
+<html>
+  <head>
+    <title>Add a Map Web Component with Events</title>
+
+    <link rel="stylesheet" type="text/css" href="./style.css" />
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body>
+    <gmp-map
+      id="marker-click-event-example"
+      center="43.4142989,-124.2301242"
+      zoom="4"
+      map-id="DEMO_MAP_ID"
+    >
+      <gmp-advanced-marker
+        position="37.4220656,-122.0840897"
+        title="Mountain View, CA"
+        gmp-clickable
+      ></gmp-advanced-marker>
+      <gmp-advanced-marker
+        position="47.648994,-122.3503845"
+        title="Seattle, WA"
+        gmp-clickable
+      ></gmp-advanced-marker>
+    </gmp-map>
+
+    <!-- prettier-ignore -->
+    <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
+      ({key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "weekly" });</script>
+  </body>
+</html>
+<!-- [END maps_web_components_events] -->

--- a/samples/web-components-events/index.ts
+++ b/samples/web-components-events/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// [START maps_web_components_events]
+// This example adds a map using web components.
+async function initMap(): Promise<void> {
+  await google.maps.importLibrary("maps");
+  await google.maps.importLibrary("marker");
+
+  console.log('Maps JavaScript API loaded.');
+
+  const advancedMarkers = document.querySelectorAll("#marker-click-event-example gmp-advanced-marker");
+  
+  for (const markerElement of advancedMarkers) {
+    const advancedMarker = markerElement as google.maps.marker.AdvancedMarkerElement;
+
+    customElements.whenDefined(advancedMarker.localName).then(async () => {
+      advancedMarker.addEventListener('gmp-click', () => {
+        const infoWindow = new google.maps.InfoWindow({
+          content: advancedMarker.title,
+        });
+
+        infoWindow.open({
+          anchor: advancedMarker,
+        });
+      });
+    });
+  }
+}
+
+initMap();
+// [END maps_web_components_events]

--- a/samples/web-components-events/package.json
+++ b/samples/web-components-events/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@js-api-samples/web-components-events",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc && bash ../jsfiddle.sh web-components-events && bash ../app.sh web-components-events && bash ../docs.sh web-components-events && npm run build:vite --workspace=. && bash ../dist.sh web-components-events",
+    "test": "tsc && npm run build:vite --workspace=.",
+    "start": "tsc && vite build --base './' && vite",
+    "build:vite": "vite build --base './'",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    
+  }
+}

--- a/samples/web-components-events/style.css
+++ b/samples/web-components-events/style.css
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* [START maps_web_components_events] */
+
+/* 
+ * Optional: Makes the sample page fill the window. 
+ */
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+/* [END maps_web_components_events] */

--- a/samples/web-components-events/tsconfig.json
+++ b/samples/web-components-events/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}


### PR DESCRIPTION
This PR does the following things:
* Migrates the web-components-events sample to js-api-samples.
* Updates the bootstrap loader to use the standard key and the weekly channel instead of beta.
* Cleans up type checking: Cast elements returned from `document.querySelectorAll` to `google.maps.marker.AdvancedMarkerElement` which allows safely removing inner file `@ts-ignore` rules.
* Removes trailing `export {}`.