### PR TITLE
feat: Adds new sample to cover the JS with div "legacy" scenario

### DIFF
--- a/samples/map-simple-js/README.md
+++ b/samples/map-simple-js/README.md
@@ -1,0 +1,35 @@
+# Google Maps JavaScript Sample
+
+## map-simple-js
+
+The map-simple-js sample demonstrates a simple example of how to create a Google Map.
+
+Follow these instructions to set up and run map-simple sample on your local computer.
+
+## Setup
+
+### Before starting run:
+
+`$npm i`
+
+### Run an example on a local web server
+
+First `cd` to the folder for the sample to run, then:
+
+`$npm start`
+
+### Build an individual example
+
+From `samples/`:
+
+`$npm run build --workspace=map-simple-js/`
+
+### Build all of the examples.
+
+From `samples/`:
+`$npm run build-all`
+
+## Feedback
+
+For feedback related to this sample, please open a new issue on
+[GitHub](https://github.com/googlemaps-samples/js-api-samples/issues).

--- a/samples/map-simple-js/index.html
+++ b/samples/map-simple-js/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--
+ @license
+ Copyright 2025 Google LLC. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+<!--
+ Note: This sample demonstrates the standard JavaScript pattern for creating a map. 
+ While this approach remains fully supported and is preferred by some developers, 
+ we recommend considering the declarative <gmp-map> web component for new projects 
+ and modern integrations.
+-->
+<!-- [START maps_map_simple_js] -->
+<html>
+
+<head>
+    <title>Simple Map</title>
+
+    <link rel="stylesheet" type="text/css" href="./style.css" />
+    <script type="module" src="./index.js"></script>
+
+    <!-- prettier-ignore -->
+    <script>(g => { var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary", q = "__ib__", m = document, b = window; b = b[c] || (b[c] = {}); var d = b.maps || (b.maps = {}), r = new Set, e = new URLSearchParams, u = () => h || (h = new Promise(async (f, n) => { await (a = m.createElement("script")); e.set("libraries", [...r] + ""); for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]); e.set("callback", c + ".maps." + q); a.src = `https://maps.${c}apis.com/maps/api/js?` + e; d[q] = f; a.onerror = () => h = n(Error(p + " could not load.")); a.nonce = m.querySelector("script[nonce]")?.nonce || ""; m.head.append(a) })); d[l] ? console.warn(p + " only loads once. Ignoring:", g) : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n)) })
+            ({ key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8", v: "weekly" });</script>
+    </body>
+</head>
+
+<body>
+    <div id="map"></div>
+</body>
+
+</html>
+<!-- [END maps_map_simple_js] -->

--- a/samples/map-simple-js/index.html
+++ b/samples/map-simple-js/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--
  @license
- Copyright 2025 Google LLC. All Rights Reserved.
+ Copyright 2026 Google LLC. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 -->
 <!--

--- a/samples/map-simple-js/index.ts
+++ b/samples/map-simple-js/index.ts
@@ -22,7 +22,7 @@ async function initMap(): Promise<void> {
     map = new Map(document.getElementById('map') as HTMLElement, {
         center: { lat: -34.397, lng: 150.644 },
         zoom: 8,
-        renderingType: RenderingType.VECTOR,
+        renderingType: "VECTOR",
     });
 }
 

--- a/samples/map-simple-js/index.ts
+++ b/samples/map-simple-js/index.ts
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2025 Google LLC. All Rights Reserved.
+ * Copyright 2026 Google LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/samples/map-simple-js/index.ts
+++ b/samples/map-simple-js/index.ts
@@ -1,0 +1,30 @@
+/*
+ * @license
+ * Copyright 2025 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Note: This sample demonstrates the standard JavaScript pattern for creating a map. 
+ * While this approach remains fully supported and is preferred by some developers, 
+ * we recommend considering the declarative <gmp-map> web component for new projects 
+ * and modern integrations.
+ */
+// [START maps_map_simple_js]
+let map: google.maps.Map;
+async function initMap(): Promise<void> {
+    // Import the needed libraries
+    const { Map, RenderingType } = (await google.maps.importLibrary(
+        'maps'
+    )) as google.maps.MapsLibrary;
+
+    // Create a new map from the div with id="map".
+    map = new Map(document.getElementById('map') as HTMLElement, {
+        center: { lat: -34.397, lng: 150.644 },
+        zoom: 8,
+        renderingType: RenderingType.VECTOR,
+    });
+}
+
+initMap();
+// [END maps_map_simple_js]

--- a/samples/map-simple-js/package.json
+++ b/samples/map-simple-js/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@js-api-samples/map-simple-js",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc && bash ../jsfiddle.sh map-simple-js && bash ../app.sh map-simple-js && bash ../docs.sh map-simple-js &&  npm run build:vite --workspace=. && bash ../dist.sh map-simple-js",
+    "test": "tsc && npm run build:vite --workspace=.",
+    "start": "tsc && vite build --base './' && vite",
+    "build:vite": "vite build --base './'",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    
+  }
+}

--- a/samples/map-simple-js/style.css
+++ b/samples/map-simple-js/style.css
@@ -1,0 +1,31 @@
+/*
+ * @license
+ * Copyright 2025 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Note: This sample demonstrates the standard JavaScript pattern for creating a map. 
+ * While this approach remains fully supported and is preferred by some developers, 
+ * we recommend considering the declarative <gmp-map> web component for new projects 
+ * and modern integrations.
+ */
+/* [START maps_map_simple_js] */
+/* 
+ * Always set the map height explicitly to define the size of the div element
+ * that contains the map. 
+ */
+#map {
+    height: 100%;
+}
+
+/* 
+ * Optional: Makes the sample page fill the window. 
+ */
+html,
+body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+/* [END maps_map_simple_js] */

--- a/samples/map-simple-js/style.css
+++ b/samples/map-simple-js/style.css
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2025 Google LLC. All Rights Reserved.
+ * Copyright 2026 Google LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /*

--- a/samples/map-simple-js/tsconfig.json
+++ b/samples/map-simple-js/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "./*.ts",
+  ]
+}


### PR DESCRIPTION
This is a new sample to cover the use case of programmatically linking `map` to a `div` element. It was created to accompany the newly updated `map-simple` in our introductory coverage (how to add a map).