### PR TITLE
Remove issue creation step on Playwright test failure

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -211,10 +211,3 @@ jobs:
         with:
           name: Test Results
           path: test-results/
-
-      - name: Create Issue on Failure
-        if: failure()
-        run: |
-          gh issue create --title "Nightly Playwright Tests Failed" --body "The nightly E2E tests failed. Please check the logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Removed the step to create an issue on failure in the Playwright workflow. In its current state nightly tests are almost guaranteed to fail.