### PR TITLE
fix: Some quick fixes for 3d-camera-position.

### DIFF
--- a/samples/3d-camera-position/index.html
+++ b/samples/3d-camera-position/index.html
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 <!-- [START maps_3d_camera_position] -->
 <html>
     <head>
-        `
         <title>Google Maps 3D - Camera Position Controller</title>
         <link rel="stylesheet" type="text/css" href="./style.css" />
         <script type="module" src="./index.js"></script>

--- a/samples/3d-camera-position/style.css
+++ b/samples/3d-camera-position/style.css
@@ -47,6 +47,7 @@ gmp-map-3d {
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 16px;
     padding: 24px;
+    margin-top: 10px;
     box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
 }
 


### PR DESCRIPTION
This PR does the following things:
* Removes stray backtick from HTML.
* Adds margin-top style so panel gets a bit of air on top.