### PR TITLE
fix: Swaps declaration order to preserve region tag

### DIFF
--- a/samples/advanced-markers-collision/index.ts
+++ b/samples/advanced-markers-collision/index.ts
@@ -5,6 +5,8 @@
  */
 
 // [START maps_advanced_markers_collision]
+const mapElement = document.querySelector('gmp-map')!;
+
 declare namespace mdc {
     namespace select {
         class MDCSelect {
@@ -14,8 +16,6 @@ declare namespace mdc {
         }
     }
 }
-
-const mapElement = document.querySelector('gmp-map')!;
 
 // Initialize and add the map
 async function init(): Promise<void> {


### PR DESCRIPTION
This PR swaps the declaration order for advanced-markers-collision, to prevent the opening region tag from being stripped. If the region tag is positioned immediately before any item that TSC strips, it will also strip the region tag since it's just a comment.