### PR TITLE
Update GH_TOKEN to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Find existing PR
         id: find_pr
         env:
-          GH_TOKEN: ${{ secrets.GH_MERGE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="$(gh pr list \
             --base main \
@@ -69,7 +69,7 @@ jobs:
         id: create_pr
         if: steps.find_pr.outputs.pr_exists != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_MERGE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="$(gh pr create \
             --base main \


### PR DESCRIPTION
Theoretically doing this will cause the PR to be created by googlemaps-bot, so there is no conflict with the token in the merge phase (as there currently seems to be).