### PR TITLE
Update GitHub token for PR approval and merging

### DIFF
--- a/.github/workflows/dist-pr.yml
+++ b/.github/workflows/dist-pr.yml
@@ -92,13 +92,13 @@ jobs:
       - name: Approve PR
         env:
           PR_URL: ${{ steps.pr.outputs.pr_url }}
-          GH_TOKEN: ${{ secrets.GH_APPROVER_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge
         env:
           PR_URL: ${{ steps.pr.outputs.pr_url }}
-          GH_TOKEN: ${{ secrets.GH_APPROVER_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Use GITHUB_TOKEN for Approval and Auto-Merge: I changed the Approve PR and Enable auto-merge steps to use secrets.GITHUB_TOKEN instead of GH_APPROVER_TOKEN.