### PR TITLE
fix: Updates dependabot config to not merge.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-npm-dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "three"
       - dependency-name: "@types/three"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      all-npm-dependencies:
-        patterns:
-          - "*"
     ignore:
       - dependency-name: "three"
       - dependency-name: "@types/three"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -32,5 +32,7 @@ jobs:
         run: gh pr comment --body "@dependabot rebase" "$PR_URL"
       - name: approve
         run: gh pr review --approve "$PR_URL"
+      # Merge step is commented out to prevent auto merging.
+      # This allows us to review version updates for breakage before publishing.
       # - name: merge
         # run: gh pr merge --auto --squash --delete-branch "$PR_URL"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -32,5 +32,5 @@ jobs:
         run: gh pr comment --body "@dependabot rebase" "$PR_URL"
       - name: approve
         run: gh pr review --approve "$PR_URL"
-      - name: merge
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+      # - name: merge
+        # run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
This PR comments out the "merge" portion of dependabot config, so now we will just merge manually. This will let us review the changes and repair any breakages before the update is merged.