### PR TITLE
chore: hoist react dependencies to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "@deck.gl/google-maps": "^9.3.4",
         "@deck.gl/layers": "^9.3.4",
         "@loaders.gl/kml": "^4.4.3",
-        "dotenv": "^17.4.2"
+        "@vis.gl/react-google-maps": "1.8.3",
+        "dotenv": "^17.4.2",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6"
       },
       "devDependencies": {
         "@eslint/css": "^1.3.0",
@@ -27,6 +30,8 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/google.maps": "^3.64.1",
         "@types/node": "^25.9.1",
+        "@types/react": "^19.2.15",
+        "@types/react-dom": "^19.2.3",
         "eslint": "^10.4.0",
         "globals": "^17.6.0",
         "prettier": "^3.8.3",
@@ -5724,95 +5729,35 @@
     },
     "samples/react-ui-kit-place-details": {
       "name": "@js-api-samples/react-ui-kit-place-details",
-      "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
-      "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
-      }
+      "version": "1.0.0"
     },
     "samples/react-ui-kit-place-details-compact": {
       "name": "@js-api-samples/react-ui-kit-place-details-compact",
-      "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
-      "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
-      }
+      "version": "1.0.0"
     },
     "samples/react-ui-kit-place-details-latlng": {
       "name": "@js-api-samples/react-ui-kit-place-details-latlng",
       "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
       "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "@vitejs/plugin-react": "^6.0.2"
       }
     },
     "samples/react-ui-kit-place-details-latlng-compact": {
       "name": "@js-api-samples/react-ui-kit-place-details-latlng-compact",
-      "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "^1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
-      "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
-      }
+      "version": "1.0.0"
     },
     "samples/react-ui-kit-search-nearby": {
       "name": "@js-api-samples/react-places-ui-kit-search-nearby",
       "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
       "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "@vitejs/plugin-react": "^6.0.2"
       }
     },
     "samples/react-ui-kit-search-text": {
       "name": "@js-api-samples/react-places-ui-kit-search-text",
       "version": "1.0.0",
-      "dependencies": {
-        "@vis.gl/react-google-maps": "1.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
-      },
       "devDependencies": {
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
-        "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "@vitejs/plugin-react": "^6.0.2"
       }
     },
     "samples/rectangle-event": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/google.maps": "^3.64.1",
     "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^10.4.0",
     "globals": "^17.6.0",
     "prettier": "^3.8.3",
@@ -35,7 +37,10 @@
     "@deck.gl/google-maps": "^9.3.4",
     "@deck.gl/layers": "^9.3.4",
     "@loaders.gl/kml": "^4.4.3",
-    "dotenv": "^17.4.2"
+    "@vis.gl/react-google-maps": "1.8.3",
+    "dotenv": "^17.4.2",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   },
   "overrides": {
     "fast-xml-parser": "5.7.1"

--- a/samples/react-ui-kit-place-details-compact/package.json
+++ b/samples/react-ui-kit-place-details-compact/package.json
@@ -8,16 +8,5 @@
     "start": "tsc && vite build --base './' && vite",
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
-  },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
-  "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
   }
 }

--- a/samples/react-ui-kit-place-details-latlng-compact/package.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/package.json
@@ -8,16 +8,5 @@
     "start": "tsc && vite build --base './' && vite",
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
-  },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "^1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
-  "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
   }
 }

--- a/samples/react-ui-kit-place-details-latlng/package.json
+++ b/samples/react-ui-kit-place-details-latlng/package.json
@@ -2,7 +2,6 @@
   "name": "@js-api-samples/react-ui-kit-place-details-latlng",
   "version": "1.0.0",
   "type": "module",
-
   "scripts": {
     "build": "bash ../build-single.sh",
     "test": "tsc && npm run build:vite --workspace=.",
@@ -10,16 +9,7 @@
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@vitejs/plugin-react": "^6.0.2"
   }
 }

--- a/samples/react-ui-kit-place-details/package.json
+++ b/samples/react-ui-kit-place-details/package.json
@@ -8,16 +8,5 @@
     "start": "tsc && vite build --base './' && vite",
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
-  },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
-  "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
   }
 }

--- a/samples/react-ui-kit-search-nearby/package.json
+++ b/samples/react-ui-kit-search-nearby/package.json
@@ -9,16 +9,7 @@
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@vitejs/plugin-react": "^6.0.2"
   }
 }

--- a/samples/react-ui-kit-search-text/package.json
+++ b/samples/react-ui-kit-search-text/package.json
@@ -9,16 +9,7 @@
     "build:vite": "vite build --base './'",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@vis.gl/react-google-maps": "1.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
-  },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@vitejs/plugin-react": "^6.0.2"
   }
 }


### PR DESCRIPTION
This PR hoists react, react-dom, and @vis.gl/react-google-maps (along with their Typescript types) to the root package.json.