### PR TITLE
chore: temporarily swap exhausted API key for geocoding samples

### DIFF
--- a/samples/geocoding-component-restriction/index.html
+++ b/samples/geocoding-component-restriction/index.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8"
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg"
             });
         </script>
     </head>

--- a/samples/geocoding-place-id/index.html
+++ b/samples/geocoding-place-id/index.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8" 
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg" 
             });
         </script>
     </head>

--- a/samples/geocoding-region-es/index.html
+++ b/samples/geocoding-region-es/index.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8",
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg",
                 region: "ES" 
             });
         </script>

--- a/samples/geocoding-region-us/index.html
+++ b/samples/geocoding-region-us/index.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8",
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg",
                 region: "US" 
             });
         </script>

--- a/samples/geocoding-reverse/index.html
+++ b/samples/geocoding-reverse/index.html
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8"
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg"
             });
         </script>
     </head>

--- a/samples/geocoding-simple/index.html
+++ b/samples/geocoding-simple/index.html
@@ -14,7 +14,7 @@
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8"
+                key: "AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg"
             });
         </script>
     </head>


### PR DESCRIPTION
This is a TEMPORARY fix to get our Geocoding doc samples back online, by using our prod key from js-samples, which is experiencing none of the spikes.