### PR TITLE
test: Disable build step until we can use dev key.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
           echo "Building changed workspaces:"
           for workspace in "${CHANGED_WORKSPACES_ARRAY[@]}"; do
             echo "  - samples/$workspace"
-            npm run build --workspace=samples/$workspace
+            # temporarily skip build: npm run build --workspace=samples/$workspace
           done
         env:
           STEPS_GET_WORKSPACES_OUTPUTS_CHANGED_WORKSPACES: ${{ steps.get_workspaces.outputs.changed_workspaces }}
@@ -202,7 +202,7 @@ jobs:
         run: npm ci
 
       - name: Build All Projects
-        run: npm run build-all
+        run: # temporarily skip build: npm run build-all
 
       - name: Generate Index (Run Once After Full Builds)
         run: bash samples/generate-index.sh

--- a/e2e/samples.spec.ts
+++ b/e2e/samples.spec.ts
@@ -143,14 +143,14 @@ if (foldersToTest.length === 0) {
 // Iterate through samples and run the same test for each one.
 foldersToTest.forEach((sampleFolder) => {
     test(`test ${sampleFolder}`, async ({ page }) => {
-        // START run the preview
+        // START run the dev server
         // Get an available port
         const port = 8080;
         const url = `http://localhost:${port}/`;
 
         const viteProcess = childProcess.spawn(
             'vite',
-            ['preview', `--port=${port}`],
+            ['dev', `--port=${port}`],
             {
                 cwd: path.join(samplesDir, sampleFolder),
                 stdio: 'inherit',
@@ -160,7 +160,7 @@ foldersToTest.forEach((sampleFolder) => {
 
         // await new Promise((resolve) => setTimeout(resolve, 500)); // Set a timeout to let the web server start.
         await page.waitForTimeout(500);
-        // END run the preview
+        // END run the dev server
 
         /**
          * Run all of the tests. Each method call either runs a test or inserts a timeout for loading.


### PR DESCRIPTION
This PR does the following things:

* Comments out the build step to avoid test failure (we removed local port restrictions from the prod key). This will be fixed once dynamic API key injection is integrated.
* Updates Playwrite e2e tests to spin up Vite in `dev` mode instead of `preview` mode; this lets Vite test directly from the source files.

These are temporary measures to get testing back online until dynamic API key injection is integrated (#1519).