### PR TITLE
feat: convert `place-photos` to an interactive random city photo generator

### DIFF
--- a/samples/place-photos/index.html
+++ b/samples/place-photos/index.html
@@ -16,7 +16,7 @@
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "GOOGLE_MAPS_API_KEY"
+                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8"
             });
         </script>
     </head>
@@ -27,6 +27,7 @@
                     <h1 id="heading"></h1>
                     <div id="summary"></div>
                 </div>
+                <button id="randomize-btn">Random City Photo</button>
             </div>
             <div id="expanded-image"></div>
         </div>

--- a/samples/place-photos/index.html
+++ b/samples/place-photos/index.html
@@ -8,13 +8,15 @@
 <html lang="en">
     <head>
         <title>Place Photos</title>
-
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+            rel="stylesheet" />
         <link rel="stylesheet" type="text/css" href="./style.css" />
         <script type="module" src="./index.js"></script>
         <script>
             // prettier-ignore
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
-                key: "AIzaSyA6myHzS10YXdcazAFalmXvDkrYCp5cLc8" 
+                key: "GOOGLE_MAPS_API_KEY"
             });
         </script>
     </head>
@@ -25,7 +27,6 @@
                     <h1 id="heading"></h1>
                     <div id="summary"></div>
                 </div>
-                <div id="gallery"></div>
             </div>
             <div id="expanded-image"></div>
         </div>

--- a/samples/place-photos/index.ts
+++ b/samples/place-photos/index.ts
@@ -5,44 +5,69 @@
  */
 
 // [START maps_place_photos]
+const CITIES = [
+    { name: 'New York', id: 'ChIJOwg_06VPwokRYv534QaPC8g' },
+    { name: 'London', id: 'ChIJdd4hrwug2EcRmSrV3Vo6llI' },
+    { name: 'Paris', id: 'ChIJD7fiBh9u5kcRYJSMaMOCCwQ' },
+    { name: 'Tokyo', id: 'ChIJ51cu8IcbXWARiRtXIothAS4' },
+    { name: 'Rome', id: 'ChIJu46S-ZZhLxMROG5lkwZ3D7k' },
+];
+
 async function init() {
     const { Place } = await google.maps.importLibrary('places');
 
-    // Use a place ID to create a new Place instance.
-    const place = new Place({
-        id: 'ChIJydSuSkkUkFQRsqhB-cEtYnw', // Woodland Park Zoo, Seattle WA
-    });
-
-    // Call fetchFields, passing the desired data fields.
-    await place.fetchFields({
-        fields: ['displayName', 'photos', 'editorialSummary'],
-    });
-
-    // Get the various HTML elements.
     const heading = document.getElementById('heading')!;
     const summary = document.getElementById('summary')!;
     const expandedImageDiv = document.getElementById('expanded-image')!;
+    const randomizeBtn = document.getElementById(
+        'randomize-btn'
+    ) as HTMLButtonElement;
 
-    // Show the display name and summary for the place.
-    heading.textContent = place.displayName!;
-    summary.textContent = place.editorialSummary!;
+    async function showRandomCityPhoto() {
+        randomizeBtn.disabled = true;
 
-    // Display a random photo.
-    if (place.photos && place.photos.length > 0) {
-        // Pick a random photo index to reduce quota usage
-        const randomIndex = Math.floor(Math.random() * place.photos.length);
-        const photo = place.photos[randomIndex];
-        const img = document.createElement('img');
-        img.alt = `Photo of ${place.displayName || 'place'}`;
-        // Fetch only the URI for this specific random photo
-        img.src = photo.getURI({ maxHeight: 800 });
-        expandedImageDiv.appendChild(img);
+        // Pick a random city
+        const city = CITIES[Math.floor(Math.random() * CITIES.length)];
 
-        if (photo.authorAttributions?.length) {
-            expandedImageDiv.appendChild(
-                createAttribution(photo.authorAttributions[0])
-            );
+        try {
+            const place = new Place({ id: city.id });
+            await place.fetchFields({
+                fields: ['displayName', 'photos', 'editorialSummary'],
+            });
+
+            heading.textContent = place.displayName || city.name;
+            summary.textContent = place.editorialSummary || '';
+            expandedImageDiv.innerHTML = '';
+
+            if (place.photos && place.photos.length > 0) {
+                // Pick one of the first 10 photos
+                const maxPhotos = Math.min(10, place.photos.length);
+                const randomIndex = Math.floor(Math.random() * maxPhotos);
+                const photo = place.photos[randomIndex];
+
+                const img = document.createElement('img');
+                img.alt = `Photo of ${place.displayName || city.name}`;
+                img.src = photo.getURI({ maxHeight: 800 });
+                expandedImageDiv.appendChild(img);
+
+                if (photo.authorAttributions?.length) {
+                    expandedImageDiv.appendChild(
+                        createAttribution(photo.authorAttributions[0])
+                    );
+                }
+            } else {
+                expandedImageDiv.textContent =
+                    'No photos available for this location.';
+            }
+        } catch (error) {
+            console.error('Failed to fetch place details:', error);
+            summary.textContent = 'Failed to load data.';
         }
+
+        // Re-enable button after 2 seconds
+        setTimeout(() => {
+            randomizeBtn.disabled = false;
+        }, 2000);
     }
 
     // Helper function to create attribution DIV.
@@ -57,6 +82,11 @@ async function init() {
         attributionLabel.rel = 'noopener noreferrer';
         return attributionLabel;
     }
+
+    randomizeBtn.addEventListener('click', () => void showRandomCityPhoto());
+
+    // Initial load
+    void showRandomCityPhoto();
 }
 
 void init();

--- a/samples/place-photos/index.ts
+++ b/samples/place-photos/index.ts
@@ -21,51 +21,24 @@ async function init() {
     // Get the various HTML elements.
     const heading = document.getElementById('heading')!;
     const summary = document.getElementById('summary')!;
-    const gallery = document.getElementById('gallery')!;
     const expandedImageDiv = document.getElementById('expanded-image')!;
 
     // Show the display name and summary for the place.
     heading.textContent = place.displayName!;
     summary.textContent = place.editorialSummary!;
 
-    // Add photos to the gallery.
-    place.photos?.forEach((photo) => {
-        const altText = 'Photo of ' + place.displayName;
-        const img = document.createElement('img');
-        const imgButton = document.createElement('button');
-        const expandedImage = document.createElement('img');
-        img.src = photo?.getURI({ maxHeight: 380 });
-        img.alt = altText;
-        imgButton.addEventListener('click', (event) => {
-            centerSelectedThumbnail(imgButton);
-            event.preventDefault();
-            expandedImage.src = img.src;
-            expandedImage.alt = altText;
-            expandedImageDiv.innerHTML = '';
-            expandedImageDiv.appendChild(expandedImage);
-            const attributionLabel = createAttribution(
-                photo.authorAttributions[0]
-            );
-            expandedImageDiv.appendChild(attributionLabel);
-        });
-
-        imgButton.addEventListener('focus', () => {
-            centerSelectedThumbnail(imgButton);
-        });
-
-        imgButton.appendChild(img);
-        gallery.appendChild(imgButton);
-    });
-
-    // Display the first photo.
+    // Display a random photo.
     if (place.photos && place.photos.length > 0) {
-        const photo = place.photos[0];
+        // Pick a random photo index to reduce quota usage
+        const randomIndex = Math.floor(Math.random() * place.photos.length);
+        const photo = place.photos[randomIndex];
         const img = document.createElement('img');
-        img.alt = 'Photo of ' + place.displayName;
-        img.src = photo.getURI();
+        img.alt = `Photo of ${place.displayName || 'place'}`;
+        // Fetch only the URI for this specific random photo
+        img.src = photo.getURI({ maxHeight: 800 });
         expandedImageDiv.appendChild(img);
 
-        if (photo.authorAttributions && photo.authorAttributions.length > 0) {
+        if (photo.authorAttributions?.length) {
             expandedImageDiv.appendChild(
                 createAttribution(photo.authorAttributions[0])
             );
@@ -83,15 +56,6 @@ async function init() {
         attributionLabel.target = '_blank';
         attributionLabel.rel = 'noopener noreferrer';
         return attributionLabel;
-    }
-
-    // Helper function to center the selected thumbnail in the gallery.
-    function centerSelectedThumbnail(element: HTMLElement) {
-        element.scrollIntoView({
-            behavior: 'smooth',
-            block: 'center',
-            inline: 'center',
-        });
     }
 }
 

--- a/samples/place-photos/index.ts
+++ b/samples/place-photos/index.ts
@@ -35,8 +35,8 @@ async function init() {
                 fields: ['displayName', 'photos', 'editorialSummary'],
             });
 
-            heading.textContent = place.displayName || city.name;
-            summary.textContent = place.editorialSummary || '';
+            heading.textContent = place.displayName ?? city.name;
+            summary.textContent = place.editorialSummary ?? '';
             expandedImageDiv.innerHTML = '';
 
             if (place.photos && place.photos.length > 0) {
@@ -46,11 +46,11 @@ async function init() {
                 const photo = place.photos[randomIndex];
 
                 const img = document.createElement('img');
-                img.alt = `Photo of ${place.displayName || city.name}`;
+                img.alt = `Photo of ${place.displayName ?? city.name}`;
                 img.src = photo.getURI({ maxHeight: 800 });
                 expandedImageDiv.appendChild(img);
 
-                if (photo.authorAttributions?.length) {
+                if (photo.authorAttributions.length) {
                     expandedImageDiv.appendChild(
                         createAttribution(photo.authorAttributions[0])
                     );

--- a/samples/place-photos/style.css
+++ b/samples/place-photos/style.css
@@ -12,88 +12,92 @@ body {
     height: 100%;
     margin: 0;
     padding: 0;
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(135deg, #1e1e2f, #252540);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 #container {
     display: flex;
-    border: 2px solid black;
-    border-radius: 10px;
-    padding: 10px;
-    max-width: 950px;
-    height: 100%;
-    max-height: 400px;
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 30px;
+    max-width: 900px;
+    width: 100%;
     box-sizing: border-box;
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.3);
+    color: white;
 }
 
 .place-overview {
-    width: 400px;
-    height: 380px;
-    overflow-x: auto;
-    position: relative;
-    margin-right: 20px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-right: 40px;
 }
 
 #info {
-    font-family: sans-serif;
-    position: sticky;
-    position: -webkit-sticky;
-    left: 0;
-    padding-bottom: 10px;
+    position: relative;
 }
 
 #heading {
-    width: 500px;
-    font-size: x-large;
-    margin-bottom: 20px;
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-top: 0;
+    margin-bottom: 15px;
+    background: linear-gradient(90deg, #fff, #a5b4fc);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
 }
 
 #summary {
-    width: 100%;
-}
-
-#gallery {
-    display: flex;
-    padding-top: 10px;
-}
-
-#gallery img {
-    width: 200px;
-    height: 200px;
-    margin: 10px;
-    border-radius: 10px;
-    cursor: pointer;
-    object-fit: cover; /* fill the area without distorting the image */
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: #cbd5e1;
 }
 
 #expanded-image {
-    display: flex;
-    height: 370px;
+    position: relative;
+    width: 400px;
+    height: 400px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: #000;
-    border-radius: 10px;
-    margin: 0 auto;
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.4);
+    transform: perspective(1000px) rotateY(-5deg);
+    transition: transform 0.5s ease;
+}
+
+#expanded-image:hover {
+    transform: perspective(1000px) rotateY(0deg) scale(1.02);
+}
+
+#expanded-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .attribution-label {
-    background-color: rgba(255, 255, 255, 0.7);
-    font-size: 10px;
-    font-family: sans-serif;
-    margin: 2px;
     position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    text-decoration: none;
+    backdrop-filter: blur(4px);
+    transition: background-color 0.3s;
 }
 
-button {
-    display: flex;
-    outline: none;
-    border: none;
-    padding: 0;
-    background: none;
-    cursor: pointer;
+.attribution-label:hover {
+    background-color: rgba(0, 0, 0, 0.8);
 }
-
-button:focus {
-    border: 2px solid blue;
-    border-radius: 10px;
-}
-
 /* [END maps_place_photos] */

--- a/samples/place-photos/style.css
+++ b/samples/place-photos/style.css
@@ -80,7 +80,35 @@ body {
 #expanded-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+}
+
+#randomize-btn {
+    margin-top: 20px;
+    padding: 12px 24px;
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: white;
+    background: linear-gradient(90deg, #4f46e5, #3b82f6);
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    transition:
+        transform 0.2s,
+        background 0.3s;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    font-family: 'Inter', sans-serif;
+    align-self: flex-start;
+}
+
+#randomize-btn:hover:not(:disabled) {
+    transform: scale(1.05);
+}
+
+#randomize-btn:disabled {
+    background: #475569;
+    cursor: not-allowed;
+    opacity: 0.7;
 }
 
 .attribution-label {


### PR DESCRIPTION
This PR overhauls the `place-photos` sample to create a more engaging, interactive experience while simultaneously protecting our API quotas. 

**Changes:**
* **Quota Optimization:** Replaced the previous 10-image eager-loading photo carousel with a single, randomized photo display. This limits the application to exactly 1 Places API fetch and 1 image request per load.
* **Random City Selection:** Added a hardcoded array of popular global destinations (New York, London, Paris, Tokyo, Rome). The sample randomly selects a city, fetches its photos, and randomly picks one of the first 10 photos to display.
* **Interactive Controls:** Added a "Random City Photo" button so users can cycle through locations without reloading the page. Implemented a 2-second debounce on the button to prevent rapid clicking and API abuse.
* **Aesthetic Overhaul:** Upgraded the UI to a modern "Glassmorphism" design with a blurred backdrop, sleek gradient backgrounds, and the `Inter` font.
* **Photo Formatting:** Switched the main display from `object-fit: cover` to `object-fit: contain` to ensure photos are never cropped and are always displayed in their entirety.

**Testing:**
* Successfully built and ran locally via `npm run test` and `vite preview`.
* Verified single-request behavior and debounce logic.