### PR TITLE
fix: restore dist.sh to populate global dist folder

### DIFF
--- a/samples/build-single.sh
+++ b/samples/build-single.sh
@@ -209,3 +209,4 @@ bash ../jsfiddle.sh "$NAME"
 bash ../app.sh "$NAME"
 bash ../docs.sh "$NAME"
 npm run build:vite --workspace=. 
+bash ../dist.sh "$NAME"

--- a/samples/dist.sh
+++ b/samples/dist.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copy/generate:
+#   - Vite build output for hosting
+
+if [ "$SKIP_DIST" = "true" ]; then
+  echo ">>>Skipping dist.sh (SKIP_DIST is true)"
+  exit 0
+fi
+
+echo ">>>Running dist.sh"
+
+NAME=$1 # The name of the folder, taken from package.json "build" line.
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )" # Script directory (/samples)
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")  # Get the parent directory (js-api-samples)
+DIST_DIR="${PROJECT_ROOT}/dist"
+SAMPLE_DIR="${PROJECT_ROOT}/dist/samples/${NAME}"
+
+echo "PROJECT_ROOT: ${PROJECT_ROOT}"
+
+# Copy Vite output files to /dist/samples/${NAME}/dist
+cp -r "${SCRIPT_DIR}/${NAME}/dist" "${SAMPLE_DIR}"


### PR DESCRIPTION
Restores dist.sh that was mistakenly removed during refactoring.