### PR TITLE
Fix cp missing files

### DIFF
--- a/samples/3d-accessibility-features/package.json
+++ b/samples/3d-accessibility-features/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-camera-boundary/package.json
+++ b/samples/3d-camera-boundary/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-camera-center/package.json
+++ b/samples/3d-camera-center/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-camera-position/package.json
+++ b/samples/3d-camera-position/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-camera-to-around/package.json
+++ b/samples/3d-camera-to-around/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-clamp-mode/package.json
+++ b/samples/3d-clamp-mode/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-coverage-map/package.json
+++ b/samples/3d-coverage-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-hero-showcase/package.json
+++ b/samples/3d-hero-showcase/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-label-toggle/package.json
+++ b/samples/3d-label-toggle/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-localization/package.json
+++ b/samples/3d-localization/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-map-45-degree-locked/package.json
+++ b/samples/3d-map-45-degree-locked/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-map-45-degree/package.json
+++ b/samples/3d-map-45-degree/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-map-events/package.json
+++ b/samples/3d-map-events/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-map-roadmap/package.json
+++ b/samples/3d-map-roadmap/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-map-styling/package.json
+++ b/samples/3d-map-styling/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-click-event/package.json
+++ b/samples/3d-marker-click-event/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-collision-behavior/package.json
+++ b/samples/3d-marker-collision-behavior/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-customization/package.json
+++ b/samples/3d-marker-customization/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-graphics/package.json
+++ b/samples/3d-marker-graphics/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-html/package.json
+++ b/samples/3d-marker-html/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-marker-interactive/package.json
+++ b/samples/3d-marker-interactive/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-mesh-flatten/package.json
+++ b/samples/3d-mesh-flatten/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-model-interactive/package.json
+++ b/samples/3d-model-interactive/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-model/package.json
+++ b/samples/3d-model/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-places-autocomplete/package.json
+++ b/samples/3d-places-autocomplete/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-places/package.json
+++ b/samples/3d-places/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polygon-click-event/package.json
+++ b/samples/3d-polygon-click-event/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polygon-extruded-hole/package.json
+++ b/samples/3d-polygon-extruded-hole/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polygon/package.json
+++ b/samples/3d-polygon/package.json
@@ -10,5 +10,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polyline-click-event/package.json
+++ b/samples/3d-polyline-click-event/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polyline-extruded/package.json
+++ b/samples/3d-polyline-extruded/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-polyline/package.json
+++ b/samples/3d-polyline/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-popover-location/package.json
+++ b/samples/3d-popover-location/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-popover-marker/package.json
+++ b/samples/3d-popover-marker/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-simple-map-declarative/package.json
+++ b/samples/3d-simple-map-declarative/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-simple-map/package.json
+++ b/samples/3d-simple-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/3d-simple-marker/package.json
+++ b/samples/3d-simple-marker/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/add-map/package.json
+++ b/samples/add-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/address-validation/package.json
+++ b/samples/address-validation/package.json
@@ -2,11 +2,11 @@
     "name": "@js-api-samples/address-validation",
     "version": "1.0.0",
     "scripts": {
-      "build": "bash ../build-single.sh",
-      "test": "tsc && npm run build:vite --workspace=.",
-      "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
-      "build:vite": "vite build --config ../../vite.config.js --base './'",
-      "preview": "vite preview --config ../../vite.config.js"
-    }
-  }
-  
+        "build": "bash ../build-single.sh",
+        "test": "tsc && npm run build:vite --workspace=.",
+        "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
+        "build:vite": "vite build --config ../../vite.config.js --base './'",
+        "preview": "vite preview --config ../../vite.config.js"
+    },
+    "author": "Google Inc."
+}

--- a/samples/advanced-markers-accessibility/package.json
+++ b/samples/advanced-markers-accessibility/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-altitude/package.json
+++ b/samples/advanced-markers-altitude/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-animation/package.json
+++ b/samples/advanced-markers-animation/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-basic-style/package.json
+++ b/samples/advanced-markers-basic-style/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-collision/package.json
+++ b/samples/advanced-markers-collision/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-draggable/package.json
+++ b/samples/advanced-markers-draggable/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-graphics/package.json
+++ b/samples/advanced-markers-graphics/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-html-simple/package.json
+++ b/samples/advanced-markers-html-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-html/package.json
+++ b/samples/advanced-markers-html/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-simple/package.json
+++ b/samples/advanced-markers-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/advanced-markers-zoom/package.json
+++ b/samples/advanced-markers-zoom/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/ai-powered-summaries-basic/package.json
+++ b/samples/ai-powered-summaries-basic/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/ai-powered-summaries/package.json
+++ b/samples/ai-powered-summaries/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/app.sh
+++ b/samples/app.sh
@@ -24,12 +24,12 @@ APP_DIR="${PROJECT_ROOT}/dist/samples/${NAME}/app"
 mkdir -p ${APP_DIR}
 
 # Copy files
-cp "${SCRIPT_DIR}/${NAME}/index.html" "${APP_DIR}/index.html"
-cp "${SCRIPT_DIR}/${NAME}/index.ts" "${APP_DIR}/index.ts"
-cp "${SCRIPT_DIR}/${NAME}/style.css" "${APP_DIR}/style.css"
-cp "${SCRIPT_DIR}/${NAME}/package.json" "${APP_DIR}/package.json"
-cp "${SCRIPT_DIR}/${NAME}/tsconfig.json" "${APP_DIR}/tsconfig.json"
-cp "${SCRIPT_DIR}/${NAME}/README.md" "${APP_DIR}/README.md"
+[ -f "${SCRIPT_DIR}/${NAME}/index.html" ] && cp "${SCRIPT_DIR}/${NAME}/index.html" "${APP_DIR}/index.html"
+[ -f "${SCRIPT_DIR}/${NAME}/index.ts" ] && cp "${SCRIPT_DIR}/${NAME}/index.ts" "${APP_DIR}/index.ts"
+[ -f "${SCRIPT_DIR}/${NAME}/style.css" ] && cp "${SCRIPT_DIR}/${NAME}/style.css" "${APP_DIR}/style.css"
+[ -f "${SCRIPT_DIR}/${NAME}/package.json" ] && cp "${SCRIPT_DIR}/${NAME}/package.json" "${APP_DIR}/package.json"
+[ -f "${SCRIPT_DIR}/${NAME}/tsconfig.json" ] && cp "${SCRIPT_DIR}/${NAME}/tsconfig.json" "${APP_DIR}/tsconfig.json"
+[ -f "${SCRIPT_DIR}/${NAME}/README.md" ] && cp "${SCRIPT_DIR}/${NAME}/README.md" "${APP_DIR}/README.md"
 
 # Generate .eslintsrc.json
 touch "${APP_DIR}/.eslintsrc.json"

--- a/samples/app.sh
+++ b/samples/app.sh
@@ -31,6 +31,17 @@ mkdir -p ${APP_DIR}
 [ -f "${SCRIPT_DIR}/${NAME}/tsconfig.json" ] && cp "${SCRIPT_DIR}/${NAME}/tsconfig.json" "${APP_DIR}/tsconfig.json"
 [ -f "${SCRIPT_DIR}/${NAME}/README.md" ] && cp "${SCRIPT_DIR}/${NAME}/README.md" "${APP_DIR}/README.md"
 
+# Copy the public folder if one is found (graphics, other static files).
+if [ -d "${SCRIPT_DIR}/${NAME}/public" ] && [ "$(ls -A "${SCRIPT_DIR}/${NAME}/public")" ]; then
+  cp -r "${SCRIPT_DIR}/${NAME}/public/"* "${APP_DIR}/"
+fi
+
+# Copy the src folder if one is found.
+if [ -d "${SCRIPT_DIR}/${NAME}/src" ] && [ "$(ls -A "${SCRIPT_DIR}/${NAME}/src")" ]; then
+  mkdir -p "${APP_DIR}/src"
+  cp -r "${SCRIPT_DIR}/${NAME}/src/"* "${APP_DIR}/src/"
+fi
+
 # Generate .eslintsrc.json
 touch "${APP_DIR}/.eslintsrc.json"
 cat > "${APP_DIR}/.eslintsrc.json" << EOF

--- a/samples/boundaries-choropleth/package.json
+++ b/samples/boundaries-choropleth/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/boundaries-click/package.json
+++ b/samples/boundaries-click/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/boundaries-simple/package.json
+++ b/samples/boundaries-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/boundaries-text-search/package.json
+++ b/samples/boundaries-text-search/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/circle-simple/package.json
+++ b/samples/circle-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-bounds-restriction/package.json
+++ b/samples/control-bounds-restriction/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-custom-state/package.json
+++ b/samples/control-custom-state/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-disableUI/package.json
+++ b/samples/control-disableUI/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-options/package.json
+++ b/samples/control-options/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-positioning-labels/package.json
+++ b/samples/control-positioning-labels/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-positioning/package.json
+++ b/samples/control-positioning/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-replacement/package.json
+++ b/samples/control-replacement/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/control-simple/package.json
+++ b/samples/control-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-datasets-point/package.json
+++ b/samples/dds-datasets-point/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-datasets-polygon-click/package.json
+++ b/samples/dds-datasets-polygon-click/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-datasets-polygon-colors/package.json
+++ b/samples/dds-datasets-polygon-colors/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-datasets-polygon/package.json
+++ b/samples/dds-datasets-polygon/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-datasets-polyline/package.json
+++ b/samples/dds-datasets-polyline/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/dds-region-viewer/package.json
+++ b/samples/dds-region-viewer/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-arclayer/package.json
+++ b/samples/deckgl-arclayer/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-heatmap/package.json
+++ b/samples/deckgl-heatmap/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-kml-updated/package.json
+++ b/samples/deckgl-kml-updated/package.json
@@ -13,5 +13,6 @@
   },
   "devDependencies": {
     "apache-arrow": "^21.1.0"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-kml/package.json
+++ b/samples/deckgl-kml/package.json
@@ -13,5 +13,6 @@
   },
   "devDependencies": {
     "apache-arrow": "^21.1.0"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-points/package.json
+++ b/samples/deckgl-points/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-polygon/package.json
+++ b/samples/deckgl-polygon/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/deckgl-tripslayer/package.json
+++ b/samples/deckgl-tripslayer/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/docs.sh
+++ b/samples/docs.sh
@@ -20,10 +20,10 @@ DOCS_DIR="${PROJECT_ROOT}/dist/samples/${NAME}/docs"
 mkdir -p ${DOCS_DIR}
 
 # Copy files
-cp "${SCRIPT_DIR}/${NAME}/index.ts" "${DOCS_DIR}/index.ts"
-cp "${SCRIPT_DIR}/${NAME}/index.js" "${DOCS_DIR}/index.js"
-cp "${SCRIPT_DIR}/${NAME}/index.html" "${DOCS_DIR}/index.html"
-cp "${SCRIPT_DIR}/${NAME}/style.css" "${DOCS_DIR}/style.css"
+[ -f "${SCRIPT_DIR}/${NAME}/index.ts" ] && cp "${SCRIPT_DIR}/${NAME}/index.ts" "${DOCS_DIR}/index.ts"
+[ -f "${SCRIPT_DIR}/${NAME}/index.js" ] && cp "${SCRIPT_DIR}/${NAME}/index.js" "${DOCS_DIR}/index.js"
+[ -f "${SCRIPT_DIR}/${NAME}/index.html" ] && cp "${SCRIPT_DIR}/${NAME}/index.html" "${DOCS_DIR}/index.html"
+[ -f "${SCRIPT_DIR}/${NAME}/style.css" ] && cp "${SCRIPT_DIR}/${NAME}/style.css" "${DOCS_DIR}/style.css"
 
 # Copy the public folder if one is found (graphics, other static files).
 if [ -d "public" ] && [ "$(ls -A public)" ]; then

--- a/samples/event-arguments/package.json
+++ b/samples/event-arguments/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/event-click-latlng/package.json
+++ b/samples/event-click-latlng/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/event-closure/package.json
+++ b/samples/event-closure/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/event-poi/package.json
+++ b/samples/event-poi/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/event-properties/package.json
+++ b/samples/event-properties/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/event-simple/package.json
+++ b/samples/event-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-component-restriction/package.json
+++ b/samples/geocoding-component-restriction/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-place-id/package.json
+++ b/samples/geocoding-place-id/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-region-es/package.json
+++ b/samples/geocoding-region-es/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-region-us/package.json
+++ b/samples/geocoding-region-us/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-reverse/package.json
+++ b/samples/geocoding-reverse/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/geocoding-simple/package.json
+++ b/samples/geocoding-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/hiding-features/package.json
+++ b/samples/hiding-features/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/infowindow-simple/package.json
+++ b/samples/infowindow-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/js-api-loader-map/package.json
+++ b/samples/js-api-loader-map/package.json
@@ -10,7 +10,7 @@
     "preview": "npm run start"
   },
   "keywords": [],
-  "author": "",
+  "author": "Google Inc.",
   "license": "MIT",
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.1.1"

--- a/samples/jsfiddle.sh
+++ b/samples/jsfiddle.sh
@@ -34,12 +34,12 @@ echo "Copy files to ${DIST_DIR}/samples/${NAME}/jsfiddle/"
 
 # Copy the public folder if one is found (graphics, other static files).
 if [ -d "public" ] && [ "$(ls -A public)" ]; then
-  cp -r public/* "${DOCS_DIR}/"
+  cp -r public/* "${DIST_DIR}/samples/${NAME}/jsfiddle/"
 fi
 
 # Copy the src folder if one is found (.js, .json, anything parseable by Vite).
 if [ -d "src" ] && [ "$(ls -A src)" ]; then
-  cp -r src/* "${DOCS_DIR}/"
+  cp -r src/* "${DIST_DIR}/samples/${NAME}/jsfiddle/"
 fi
 
 pushd "${DIST_DIR}/samples/${NAME}/jsfiddle"

--- a/samples/jsfiddle.sh
+++ b/samples/jsfiddle.sh
@@ -27,10 +27,10 @@ echo "NAME: ${NAME}"
 mkdir -p "${DIST_DIR}/samples/${NAME}/jsfiddle"
 
 # Copy files
-echo "Copy ${SCRIPT_DIR}/${NAME}/index.js to ${DIST_DIR}/samples/${NAME}/jsfiddle/demo.js"
-cp "${SCRIPT_DIR}/${NAME}/index.js" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.js"
-cp "${SCRIPT_DIR}/${NAME}/index.html" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.html"
-cp "${SCRIPT_DIR}/${NAME}/style.css" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.css"
+echo "Copy files to ${DIST_DIR}/samples/${NAME}/jsfiddle/"
+[ -f "${SCRIPT_DIR}/${NAME}/index.js" ] && cp "${SCRIPT_DIR}/${NAME}/index.js" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.js"
+[ -f "${SCRIPT_DIR}/${NAME}/index.html" ] && cp "${SCRIPT_DIR}/${NAME}/index.html" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.html"
+[ -f "${SCRIPT_DIR}/${NAME}/style.css" ] && cp "${SCRIPT_DIR}/${NAME}/style.css" "${DIST_DIR}/samples/${NAME}/jsfiddle/demo.css"
 
 # Copy the public folder if one is found (graphics, other static files).
 if [ -d "public" ] && [ "$(ls -A public)" ]; then
@@ -46,21 +46,25 @@ pushd "${DIST_DIR}/samples/${NAME}/jsfiddle"
 
 # Remove region tags from files by type, since they all have different comment conventions.
 # We use a conditional here since sed behaves differently on Linux.
-echo "Remove region tags from ${DIST_DIR}/samples/${NAME}/jsfiddle/demo.js"
-sed -i.sed-back "s#// \[START .*]##g" "demo.js" && rm *.sed-back
-sed -i.sed-back "s#// \[END .*]##g" "demo.js" && rm *.sed-back
-sed -i.sed-back "s#/\* \[START .*] \*/##g" "demo.js" && rm *.sed-back
-sed -i.sed-back "s#/\* \[END .*] \*/##g" "demo.js"  && rm *.sed-back
+echo "Remove region tags from JS"
+if [ -f "demo.js" ]; then
+  sed -i.sed-back "s#// \[START .*]##g" "demo.js" && rm *.sed-back
+  sed -i.sed-back "s#// \[END .*]##g" "demo.js" && rm *.sed-back
+  sed -i.sed-back "s#/\* \[START .*] \*/##g" "demo.js" && rm *.sed-back
+  sed -i.sed-back "s#/\* \[END .*] \*/##g" "demo.js"  && rm *.sed-back
+fi
 
+echo "Remove region tags from HTML"
+if [ -f "demo.html" ]; then
+  sed -i.sed-back "s/<!--[[:space:]]*\[START .*\][[:space:]]*-->//g" "demo.html" && rm *.sed-back
+  sed -i.sed-back "s/<!--[[:space:]]*\[END .*\][[:space:]]*-->//g" "demo.html" && rm *.sed-back
+fi
 
-echo "Remove region tags from ${DIST_DIR}/samples/${NAME}/jsfiddle/demo.html"
-sed -i.sed-back "s/<!--[[:space:]]*\[START .*\][[:space:]]*-->//g" "demo.html" && rm *.sed-back
-sed -i.sed-back "s/<!--[[:space:]]*\[END .*\][[:space:]]*-->//g" "demo.html" && rm *.sed-back
-
-
-echo "Remove region tags from ${DIST_DIR}/samples/${NAME}/jsfiddle/demo.css"
-sed -i.sed-back "s#/\* \[START maps_.*] \*/##g" "demo.css" && rm *.sed-back
-sed -i.sed-back "s#/\* \[END maps_.*] \*/##g" "demo.css"  && rm *.sed-back
+echo "Remove region tags from CSS"
+if [ -f "demo.css" ]; then
+  sed -i.sed-back "s#/\* \[START maps_.*] \*/##g" "demo.css" && rm *.sed-back
+  sed -i.sed-back "s#/\* \[END maps_.*] \*/##g" "demo.css"  && rm *.sed-back
+fi
 
 # after that other cleanup, re-run prettier to remove excess newlines
 npx prettier -w . --ignore-path /dev/null

--- a/samples/layer-data-event/package.json
+++ b/samples/layer-data-event/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/layer-data-quakes-red/package.json
+++ b/samples/layer-data-quakes-red/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/layer-data-quakes-simple/package.json
+++ b/samples/layer-data-quakes-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/layer-data-simple/package.json
+++ b/samples/layer-data-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/layer-data-style/package.json
+++ b/samples/layer-data-style/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/map-drawing-terradraw/package.json
+++ b/samples/map-drawing-terradraw/package.json
@@ -17,5 +17,6 @@
     "@types/google.maps": "latest",
     "typescript": "^5.9.3",
     "vite": "^8.1.4"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/map-events/package.json
+++ b/samples/map-events/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/map-projection-simple/package.json
+++ b/samples/map-projection-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/map-simple-js/package.json
+++ b/samples/map-simple-js/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/map-simple/package.json
+++ b/samples/map-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-autocomplete-basic-map/package.json
+++ b/samples/place-autocomplete-basic-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-autocomplete-data-session/package.json
+++ b/samples/place-autocomplete-data-session/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-autocomplete-data-simple/package.json
+++ b/samples/place-autocomplete-data-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-autocomplete-element/package.json
+++ b/samples/place-autocomplete-element/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-autocomplete-map/package.json
+++ b/samples/place-autocomplete-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-class/package.json
+++ b/samples/place-class/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-nearby-search/package.json
+++ b/samples/place-nearby-search/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-photos/package.json
+++ b/samples/place-photos/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/place-reviews/package.json
+++ b/samples/place-reviews/package.json
@@ -7,5 +7,6 @@
         "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
         "build:vite": "vite build --config ../../vite.config.js --base './'",
         "preview": "vite preview --config ../../vite.config.js"
-    }
+    },
+    "author": "Google Inc."
 }

--- a/samples/place-text-search/package.json
+++ b/samples/place-text-search/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/places-autocomplete-addressform/package.json
+++ b/samples/places-autocomplete-addressform/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/places-placeid-finder/package.json
+++ b/samples/places-placeid-finder/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/polyline-complex/package.json
+++ b/samples/polyline-complex/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/polyline-remove/package.json
+++ b/samples/polyline-remove/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/polyline-simple/package.json
+++ b/samples/polyline-simple/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-place-details-compact/package.json
+++ b/samples/react-ui-kit-place-details-compact/package.json
@@ -8,5 +8,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-place-details-latlng-compact/package.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/package.json
@@ -8,5 +8,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-place-details-latlng/package.json
+++ b/samples/react-ui-kit-place-details-latlng/package.json
@@ -11,5 +11,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-place-details/package.json
+++ b/samples/react-ui-kit-place-details/package.json
@@ -8,5 +8,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-search-nearby/package.json
+++ b/samples/react-ui-kit-search-nearby/package.json
@@ -11,5 +11,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/react-ui-kit-search-text/package.json
+++ b/samples/react-ui-kit-search-text/package.json
@@ -11,5 +11,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/rectangle-event/package.json
+++ b/samples/rectangle-event/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-compute-routes/package.json
+++ b/samples/routes-compute-routes/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-get-alternatives/package.json
+++ b/samples/routes-get-alternatives/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-get-directions-panel/package.json
+++ b/samples/routes-get-directions-panel/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-get-directions/package.json
+++ b/samples/routes-get-directions/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-markers/package.json
+++ b/samples/routes-markers/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/routes-route-matrix/package.json
+++ b/samples/routes-route-matrix/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/streetview-overlays/package.json
+++ b/samples/streetview-overlays/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/test-example/package.json
+++ b/samples/test-example/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/ui-kit-place-details-compact/package.json
+++ b/samples/ui-kit-place-details-compact/package.json
@@ -2,11 +2,11 @@
     "name": "@js-api-samples/ui-kit-place-details-compact",
     "version": "1.0.0",
     "scripts": {
-      "build": "bash ../build-single.sh",
-      "test": "tsc && npm run build:vite --workspace=.",
-      "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
-      "build:vite": "vite build --config ../../vite.config.js --base './'",
-      "preview": "vite preview --config ../../vite.config.js"
-    }
-  }
-  
+        "build": "bash ../build-single.sh",
+        "test": "tsc && npm run build:vite --workspace=.",
+        "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
+        "build:vite": "vite build --config ../../vite.config.js --base './'",
+        "preview": "vite preview --config ../../vite.config.js"
+    },
+    "author": "Google Inc."
+}

--- a/samples/ui-kit-place-details/package.json
+++ b/samples/ui-kit-place-details/package.json
@@ -2,11 +2,11 @@
     "name": "@js-api-samples/ui-kit-place-details",
     "version": "1.0.0",
     "scripts": {
-      "build": "bash ../build-single.sh",
-      "test": "tsc && npm run build:vite --workspace=.",
-      "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
-      "build:vite": "vite build --config ../../vite.config.js --base './'",
-      "preview": "vite preview --config ../../vite.config.js"
-    }
-  }
-  
+        "build": "bash ../build-single.sh",
+        "test": "tsc && npm run build:vite --workspace=.",
+        "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
+        "build:vite": "vite build --config ../../vite.config.js --base './'",
+        "preview": "vite preview --config ../../vite.config.js"
+    },
+    "author": "Google Inc."
+}

--- a/samples/ui-kit-place-search-nearby/package.json
+++ b/samples/ui-kit-place-search-nearby/package.json
@@ -2,11 +2,11 @@
     "name": "@js-api-samples/ui-kit-place-search-nearby-nearby",
     "version": "1.0.0",
     "scripts": {
-      "build": "bash ../build-single.sh",
-      "test": "tsc && npm run build:vite --workspace=.",
-      "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
-      "build:vite": "vite build --config ../../vite.config.js --base './'",
-      "preview": "vite preview --config ../../vite.config.js"
-    }
-  }
-  
+        "build": "bash ../build-single.sh",
+        "test": "tsc && npm run build:vite --workspace=.",
+        "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
+        "build:vite": "vite build --config ../../vite.config.js --base './'",
+        "preview": "vite preview --config ../../vite.config.js"
+    },
+    "author": "Google Inc."
+}

--- a/samples/ui-kit-place-search-text/package.json
+++ b/samples/ui-kit-place-search-text/package.json
@@ -2,11 +2,11 @@
     "name": "@js-api-samples/ui-kit-place-search-text",
     "version": "1.0.0",
     "scripts": {
-      "build": "bash ../build-single.sh",
-      "test": "tsc && npm run build:vite --workspace=.",
-      "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
-      "build:vite": "vite build --config ../../vite.config.js --base './'",
-      "preview": "vite preview --config ../../vite.config.js"
-    }
-  }
-  
+        "build": "bash ../build-single.sh",
+        "test": "tsc && npm run build:vite --workspace=.",
+        "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
+        "build:vite": "vite build --config ../../vite.config.js --base './'",
+        "preview": "vite preview --config ../../vite.config.js"
+    },
+    "author": "Google Inc."
+}

--- a/samples/weather-api-current-compact/package.json
+++ b/samples/weather-api-current-compact/package.json
@@ -7,5 +7,6 @@
     "start": "vite --port 5173",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/web-components-events/package.json
+++ b/samples/web-components-events/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/web-components-map/package.json
+++ b/samples/web-components-map/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }

--- a/samples/web-components-markers/package.json
+++ b/samples/web-components-markers/package.json
@@ -7,5 +7,6 @@
     "start": "tsc && vite build --config ../../vite.config.js --base './' && vite --config ../../vite.config.js",
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
-  }
+  },
+  "author": "Google Inc."
 }


### PR DESCRIPTION
### 🐛 Fix CI build crashes for React Samples and force full site recovery

**Context:**
The previous PR that forced a full rebuild successfully triggered the CI for all samples, but the build pipeline halted midway through when processing the React samples (`react-ui-kit-*`). This caused the Firebase deployment step to be entirely skipped, leaving the hosted site as a 404.

**Why the build crashed:**
The build scripts (`docs.sh`, `app.sh`, `jsfiddle.sh`) were hardcoded to copy `index.ts`, `index.js`, and `style.css` from the root directory of every sample. Because React samples keep their code in a `src/` directory instead of the root, the `cp` commands failed with a `cp: cannot stat` error, instantly crashing the pipeline.

**Changes in this PR:**
1. **Graceful File Copying:** Wrapped all root-level file copy operations in `docs.sh`, `app.sh`, and `jsfiddle.sh` with existence checks (`[ -f ... ]`). The scripts will now gracefully skip missing files without halting the pipeline.
2. **`jsfiddle.sh` Bug Fix:** Fixed a bug where `src` and `public` folders were incorrectly copying into an undefined `$DOCS_DIR` variable. They now correctly copy into the `jsfiddle/` directory.
3. **`app.sh` React Support:** Updated `app.sh` to copy `src/` and `public/` directories to ensure React apps actually function when opened in Cloud Shell.
4. **Forced CI Rebuild:** Modified the `author` field across all 100+ `package.json` files to dirty every workspace again. This forces the CI's `find-changes.sh` to re-trigger a full build and deployment to fully restore the site from the 404s.