### PR TITLE
chore(eslint): ignore playwright generated directories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,13 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import stylistic from '@stylistic/eslint-plugin';
 
 export default defineConfig([
-    globalIgnores(['**/dist/*', 'samples/*/*.js', '**/package-lock.json']),
+    globalIgnores([
+        '**/dist/*',
+        'samples/*/*.js',
+        '**/package-lock.json',
+        '**/playwright-report/*',
+        '**/test-results/*',
+    ]),
     {
         files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
         plugins: { js },


### PR DESCRIPTION
### Description

This PR updates `eslint.config.mjs` to globally ignore the `playwright-report/` and `test-results/` output directories. 

Previously, when Playwright ran locally, it would generate markdown reports (such as `playwright-report/index.html` and markdown summary files) in the root of the repository. The ESLint markdown plugin (`eslint-plugin-markdown`) would then scan these dynamically generated files and trigger formatting errors (`no-multiple-h1`, `fenced-code-language`), causing the `npm run check-and-fix` CI script to unexpectedly fail. 

Ignoring these output directories prevents these false-positive linting errors and ensures `check-and-fix` runs reliably regardless of local test executions.