### PR TITLE
chore: Migrate package.json and vite.config.js to use ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@googlemaps-samples/js-api-samples",
   "version": "1.0.0",
+  "type": "module",
   "description": "Samples for the Google Maps JavaScript API.",
   "scripts": {
     "build-all": "npm run clean && npm run build-all-parallel && npm run generate-index",

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,10 @@ import { defineConfig } from 'vite';
 import dotenv from 'dotenv';
 import { resolve } from 'path';
 
-dotenv.config({ path: resolve(__dirname, '.env') });
+dotenv.config({ path: resolve(import.meta.dirname, '.env') });
 
 export default defineConfig(() => {
-    const projectRepoRoot = resolve(__dirname);
+    const projectRepoRoot = resolve(import.meta.dirname);
     const workspaceDir = process.cwd();
     const isSample =
         workspaceDir !== projectRepoRoot && workspaceDir.includes('/samples/');


### PR DESCRIPTION
### **Description:**

**What this PR does:**
This PR future-proofs the repository by officially migrating the root workspace to use native ES Modules (`"type": "module"`), resolving deprecation warnings thrown by Vite 8's new native config loader.

**Why this is needed:**
When running samples locally, Vite was throwing the following warnings:
> `(!) Your Vite config uses features that are unsupported by configLoader: 'native', which is planned to become the default in a future major version of Vite`

Vite is phasing out its legacy config loader which historically allowed ESM syntax (and polyfilled CommonJS globals like `__dirname`) inside `.js` files. By natively migrating the workspace to ESM, we ensure the build pipeline won't break in the next major Vite release.

**Changes included:**
*   **`package.json`**: Added `"type": "module"` to the root workspace to natively enable ES Modules across the repo.
*   **`vite.config.js`**: Replaced the legacy CommonJS `__dirname` global with the modern ES Module equivalent: `import.meta.dirname`. 