### PR TITLE
chore: Updates tsconfig to use 'react' for jsx.

### DIFF
--- a/samples/rgm-basic-map/README.md
+++ b/samples/rgm-basic-map/README.md
@@ -2,7 +2,8 @@
 
 ## rgm-basic-map
 
-React Google Maps Library - Basic Map
+This sample demonstrates using React with the vis.gl wrapper to create
+a map with an Advanced Marker.
 
 ## Setup
 

--- a/tsconfig.react-base.json
+++ b/tsconfig.react-base.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "types": ["vite/client", "google.maps"]
   }


### PR DESCRIPTION
This PR updates the root react tsconfig to use "jsx": "react".  This was done to prevent region tags from being stripped. Here is the explanation:

When TypeScript uses the new "react-jsx" runtime, it has to completely rewrite the Abstract Syntax Tree (AST) to inject those import { jsx } statements at the top. When it does that AST rewrite, it notorious for losing track of "unattached" trailing comments and dropping them from the output file entirely.

When it is set to "jsx": "react-jsx" this tells TypeScript to use the new automatic JSX runtime, which automatically injects `import { jsx as _jsx }` at the top of the output JS file.  By switching back to "jsx": "react", we prevented TypeScript from rewriting the file's AST, which stopped the import injection at the top AND stopped it from accidentally deleting the trailing [END] tag at the bottom.
