### PR TITLE
chore: Fix build pipeline and routing for React samples.

### DIFF
--- a/samples/build-single.sh
+++ b/samples/build-single.sh
@@ -167,7 +167,6 @@ npx eslint
 
 # clean comments for empty lines, and then clean up, to preserve newlines
 sed -i.sed-back 's#^$#// TMP EMPTY LINE#g' *.ts && rm *.sed-back
-set +e
 rm -rf dist
 set +e
 npx tsc

--- a/samples/build-single.sh
+++ b/samples/build-single.sh
@@ -168,6 +168,8 @@ npx eslint
 # clean comments for empty lines, and then clean up, to preserve newlines
 sed -i.sed-back 's#^$#// TMP EMPTY LINE#g' *.ts && rm *.sed-back
 set +e
+rm -rf dist
+set +e
 npx tsc
 status=$? 
 set -e
@@ -207,6 +209,10 @@ set -e
 
 bash ../jsfiddle.sh "$NAME"
 bash ../app.sh "$NAME"
-bash ../docs.sh "$NAME"
+if [ -f "src/app.tsx" ] || [ -f "src/app.jsx" ] || [ -f "src/app.js" ]; then
+  bash ../react-docs.sh "$NAME"
+else
+  bash ../docs.sh "$NAME"
+fi
 npm run build:vite --workspace=. 
 bash ../dist.sh "$NAME"

--- a/samples/dist.sh
+++ b/samples/dist.sh
@@ -20,4 +20,5 @@ SAMPLE_DIR="${PROJECT_ROOT}/dist/samples/${NAME}"
 echo "PROJECT_ROOT: ${PROJECT_ROOT}"
 
 # Copy Vite output files to /dist/samples/${NAME}/dist
+rm -rf "${SAMPLE_DIR}/dist"
 cp -r "${SCRIPT_DIR}/${NAME}/dist" "${SAMPLE_DIR}"

--- a/samples/react-docs.sh
+++ b/samples/react-docs.sh
@@ -16,16 +16,29 @@ echo "PROJECT_ROOT: ${PROJECT_ROOT}"
 
 DOCS_DIR="${PROJECT_ROOT}/dist/samples/${NAME}/docs"
 
-# Create two new folders.
-mkdir -p ${DOCS_DIR}/src
+# Create new folders.
+mkdir -p "${DOCS_DIR}/src"
 
 # Copy files
-cp "${SCRIPT_DIR}/${NAME}/src/app.js" "${DOCS_DIR}/src/app.js"
-cp "${SCRIPT_DIR}/${NAME}/src/app.tsx" "${DOCS_DIR}/src/app.tsx"
-cp "${SCRIPT_DIR}/${NAME}/src/styles.css" "${DOCS_DIR}/src/styles.css"
-cp "${SCRIPT_DIR}/${NAME}/index.html" "${DOCS_DIR}/index.html"
+if [ -f "${SCRIPT_DIR}/${NAME}/dist/app.js" ]; then
+  cp "${SCRIPT_DIR}/${NAME}/dist/app.js" "${DOCS_DIR}/app.js"
+fi
 
-# Copy the data folder if one is found.
-if [ -d "public" ] && [ "$(ls -A public)" ]; then
-  cp -r public/* "${DOCS_DIR}/"
+if [ -f "${SCRIPT_DIR}/${NAME}/src/app.tsx" ]; then
+  cp "${SCRIPT_DIR}/${NAME}/src/app.tsx" "${DOCS_DIR}/src/app.tsx"
+fi
+
+if [ -f "${SCRIPT_DIR}/${NAME}/style.css" ]; then
+  cp "${SCRIPT_DIR}/${NAME}/style.css" "${DOCS_DIR}/style.css"
+elif [ -f "${SCRIPT_DIR}/${NAME}/src/styles.css" ]; then
+  cp "${SCRIPT_DIR}/${NAME}/src/styles.css" "${DOCS_DIR}/style.css"
+fi
+
+if [ -f "${SCRIPT_DIR}/${NAME}/index.html" ]; then
+  cp "${SCRIPT_DIR}/${NAME}/index.html" "${DOCS_DIR}/index.html"
+fi
+
+# Copy the public folder if one is found (graphics, other static files).
+if [ -d "${SCRIPT_DIR}/${NAME}/public" ] && [ "$(ls -A ${SCRIPT_DIR}/${NAME}/public)" ]; then
+  cp -r "${SCRIPT_DIR}/${NAME}/public/"* "${DOCS_DIR}/"
 fi

--- a/samples/react-ui-kit-place-details-compact/package.json
+++ b/samples/react-ui-kit-place-details-compact/package.json
@@ -9,5 +9,6 @@
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/react-ui-kit-place-details-latlng-compact/package.json
+++ b/samples/react-ui-kit-place-details-latlng-compact/package.json
@@ -9,5 +9,6 @@
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/react-ui-kit-place-details-latlng/package.json
+++ b/samples/react-ui-kit-place-details-latlng/package.json
@@ -12,5 +12,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/react-ui-kit-place-details/package.json
+++ b/samples/react-ui-kit-place-details/package.json
@@ -9,5 +9,6 @@
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/react-ui-kit-search-nearby/package.json
+++ b/samples/react-ui-kit-search-nearby/package.json
@@ -12,5 +12,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/react-ui-kit-search-text/package.json
+++ b/samples/react-ui-kit-search-text/package.json
@@ -12,5 +12,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.2"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/rgm-autocomplete/package.json
+++ b/samples/rgm-autocomplete/package.json
@@ -9,5 +9,6 @@
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }

--- a/samples/rgm-basic-map/package.json
+++ b/samples/rgm-basic-map/package.json
@@ -9,5 +9,6 @@
     "build:vite": "vite build --config ../../vite.config.js --base './'",
     "preview": "vite preview --config ../../vite.config.js"
   },
-  "author": "Google LLC"
+  "author": "Google LLC",
+  "buildRevision": 1
 }


### PR DESCRIPTION
**Overview**
This PR fixes a bug in our sample build pipeline where React/Vite samples were incorrectly being routed through the vanilla `docs.sh` script, causing their `src/` directories to be destructively flattened and breaking DevSite macro expectations.

**Key Changes:**
* **`samples/dist.sh`**:
  * Updated dist.sh to delete dist prior to copying. This ensures hashed assets don't perpetually accumulate over successive local builds.
* **`samples/build-single.sh`**: 
  * Added conditional detection for React projects (checking for `src/app.tsx|jsx|js`). React samples are now properly routed to `react-docs.sh`.
  * Added a `rm -rf dist` step prior to `tsc` execution. This ensures Vite's hashed assets don't perpetually accumulate over successive local builds.
* **`samples/react-docs.sh`**: 
  * Completely modernized to satisfy both DevSite live-render macros and snippet tab structures.
  * Preserves original source structure by safely nesting `app.tsx` inside `docs/src/`.
  * Drops the compiled `app.js` and `style.css` directly into the `docs/` root exactly where DevSite expects them for live rendering.
* **Triggered React Rebuilds**:
  * Added a harmless `"buildRevision": 1` field to the `package.json` of all React (`rgm-*` and `react-ui-kit-*`) samples to cleanly force a CI rebuild and output sync without polluting the source files. 