### PR TITLE
chore: sync deck.gl dependencies and group dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
     ignore:
       - dependency-name: "three"
       - dependency-name: "@types/three"
+    groups:
+      deckgl:
+        patterns:
+          - "@deck.gl/*"
 
   - package-ecosystem: "github-actions" # zizmor: ignore[dependabot-cooldown]
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "samples/*"
       ],
       "dependencies": {
-        "@deck.gl/core": "^9.3.7",
-        "@deck.gl/geo-layers": "^9.3.8",
-        "@deck.gl/google-maps": "^9.3.7",
-        "@deck.gl/layers": "^9.3.7",
+        "@deck.gl/core": "^9.3.10",
+        "@deck.gl/geo-layers": "^9.3.10",
+        "@deck.gl/google-maps": "^9.3.10",
+        "@deck.gl/layers": "^9.3.10",
         "@loaders.gl/kml": "^4.4.4",
         "@vis.gl/react-google-maps": "1.8.3",
         "dotenv": "^17.4.2",
@@ -42,15 +42,17 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.3.7",
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.10.tgz",
+      "integrity": "sha512-BAJ6r+eRV4euuGcIi2SnlzrodgZ+sD2VuXsoL1DER0LwwKXmKmQu6WA8ax6DB9KFsBghLVoTUN5zaCGF6uKHuQ==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/core": "^4.4.3",
         "@loaders.gl/images": "^4.4.3",
-        "@luma.gl/core": "^9.3.3",
-        "@luma.gl/engine": "^9.3.3",
-        "@luma.gl/shadertools": "^9.3.3",
-        "@luma.gl/webgl": "^9.3.3",
+        "@luma.gl/core": "^9.3.5",
+        "@luma.gl/engine": "^9.3.5",
+        "@luma.gl/shadertools": "^9.3.5",
+        "@luma.gl/webgl": "^9.3.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -79,7 +81,9 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.3.8",
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.10.tgz",
+      "integrity": "sha512-MH6/MyWTiJ02yxrkMz6bMP1Z8d13JEmxogwZmWx2I9XLDNpCnLxnXElnVxxvDvhIbWdWq/i/xl8Kn9WOLiywBg==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/3d-tiles": "^4.4.3",
@@ -111,26 +115,30 @@
       }
     },
     "node_modules/@deck.gl/google-maps": {
-      "version": "9.3.7",
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-9.3.10.tgz",
+      "integrity": "sha512-S84742VZ0SAdYGNVp4C4qHHeuREFLoUZHc9AP3boC69lgosOrHGHNK35zRr2sFYJNhJBLNTiTmPAHdUjIZ4yHw==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/webgl": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.5",
         "@math.gl/core": "^4.1.0",
         "@types/google.maps": "^3.48.6"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.3",
-        "@luma.gl/webgl": "~9.3.3"
+        "@luma.gl/core": "~9.3.5",
+        "@luma.gl/webgl": "~9.3.5"
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.3.7",
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.10.tgz",
+      "integrity": "sha512-F9CRJlRWXvTKlgjKmmTotm0cA5V7I1zMtdnwJbjBZTyCJ4skuskbIIt6f+BSQ+rSxM2uW4q5/8VkcCJ2SePhXg==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/images": "^4.4.3",
         "@loaders.gl/schema": "^4.4.3",
-        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.5",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
@@ -141,8 +149,8 @@
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
         "@loaders.gl/core": "^4.4.3",
-        "@luma.gl/core": "~9.3.3",
-        "@luma.gl/engine": "~9.3.3"
+        "@luma.gl/core": "~9.3.5",
+        "@luma.gl/engine": "~9.3.5"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
@@ -1581,14 +1589,14 @@
       }
     },
     "node_modules/@loaders.gl/kml": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/kml/-/kml-4.4.4.tgz",
-      "integrity": "sha512-MqAq+MW5F/6S0i8cpg9w3xMtdnI2rNZQV/211sbNZ85Rr/PZiazZtmapqLTaRWCYsg4TLhW7pO9qJ1e8k9I4Uw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/kml/-/kml-4.4.5.tgz",
+      "integrity": "sha512-AAag2wtWlCAoBz3fYkDQkGIzfICNAwN2wacSr8616wf8Df89N33i5Umaj97tJwXzL9o0TiNYBMsiO/QqyEFFKw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/gis": "4.4.4",
-        "@loaders.gl/loader-utils": "4.4.4",
-        "@loaders.gl/schema": "4.4.4",
+        "@loaders.gl/gis": "4.4.5",
+        "@loaders.gl/loader-utils": "4.4.5",
+        "@loaders.gl/schema": "4.4.5",
         "@tmcw/togeojson": "^4.5.0",
         "@xmldom/xmldom": "^0.8.12"
       },
@@ -1597,9 +1605,9 @@
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/geoarrow": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.4.tgz",
-      "integrity": "sha512-5IygnXr1J+IBYKA+ZEOytifS4skx/L9Rk6J/OVmNzV5gVsKQtxwA3b69GDPD61dcNAYCegA3Y4wpHO+JEqLzrg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.5.tgz",
+      "integrity": "sha512-uUWp+5nZxQe6Sv/o36R6jcmCCNhguY0VhjougyMoH6FWqF6iJHrOnwx5UdEtvkw/zV9mHabs05Hv91dBvhfljQ==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/polygon": "^4.1.0",
@@ -1610,15 +1618,15 @@
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/gis": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.4.tgz",
-      "integrity": "sha512-KUonvWVntPhZKx4jjoGezXLp4R1RgS6n4FMLdOYX1fUJZ48fRDQVA28Y/PbqDgBHm/9pJ7Aq3TlOvjbr2KUsVA==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.5.tgz",
+      "integrity": "sha512-r3klnZ6jjzaEZlUSCmGufPbH1pQpM5PCcGS70zLlGIFbpJPo80gaXDtZDVOSQvpWmqY8u8d7/6moAsogVoymzA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/geoarrow": "4.4.4",
-        "@loaders.gl/loader-utils": "4.4.4",
-        "@loaders.gl/schema": "4.4.4",
-        "@loaders.gl/schema-utils": "4.4.4",
+        "@loaders.gl/geoarrow": "4.4.5",
+        "@loaders.gl/loader-utils": "4.4.5",
+        "@loaders.gl/schema": "4.4.5",
+        "@loaders.gl/schema-utils": "4.4.5",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^4.1.0",
         "pbf": "^3.2.1"
@@ -1628,21 +1636,21 @@
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.4.tgz",
-      "integrity": "sha512-+0IizJUB6GvPQjl2xC2V1vpcMPcidZykWy27LFnIIqG1lesxfALnFmRoq9MjbOj2TPcUo7VSBxl8z55qRlX0rQ==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.5.tgz",
+      "integrity": "sha512-c4h2RUMEru+hbfvgZEIy5cLQKyQka2TPQZW/2Wy+yIPr3FU7RKwfp+vLwIfir6Xkdn2zniWyWretZwE02aY/Ug==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.4.4",
-        "@loaders.gl/worker-utils": "4.4.4",
+        "@loaders.gl/schema": "4.4.5",
+        "@loaders.gl/worker-utils": "4.4.5",
         "@probe.gl/log": "^4.1.1",
         "@probe.gl/stats": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/schema": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.4.tgz",
-      "integrity": "sha512-3spgUoN505V2OprDDzww5nhWfn8Htupcfdr+/lxswAhCbGjwM3RWzA3Zif3dW6ZxOCeSIRJ4GNON78Eiede2dw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.5.tgz",
+      "integrity": "sha512-q2XNquegw+hX+ZEshacKYL/+FKBUIS5FHA+2Ft3JWmcNiR6umGnYCdXQhDcFCqAm8Ks87fMCV+z/zTloxaIZgQ==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
@@ -1650,12 +1658,12 @@
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/schema-utils": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.4.tgz",
-      "integrity": "sha512-/ykSrQlfn7Lx+kmQNuGzTaywLVy2RoaAZ5YiEXkP9UJ+4lYY2wP5KgUlQGwODDdzNPLFmYzd+FXeE9GEmlXIUg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.5.tgz",
+      "integrity": "sha512-vi6AROLWvoLIN609tVmchwotTaHK5rHv8SWjoVUWLhPCXmIc9npz0rCl7NJScCgr7UjYifZG1rWOnrAxaYTlyA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.4.4",
+        "@loaders.gl/schema": "4.4.5",
         "@math.gl/types": "^4.1.0",
         "@types/geojson": "^7946.0.7",
         "apache-arrow": ">= 17.0.0"
@@ -1665,9 +1673,9 @@
       }
     },
     "node_modules/@loaders.gl/kml/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.4.tgz",
-      "integrity": "sha512-UNQCwK7tHd7Qh0K7e6Flvac8qd14SoAgaN8SOjggd5ngYqwytOQiAo5uEuhRN+r7+EqdwU+qwcpRtjYByT+RqA==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.5.tgz",
+      "integrity": "sha512-ZQDoM6f/HpZ3Lzj6vjtPHXSvi+cUK0QG7yJz+MKWAokmeWa98WMZwswS8zkn/qNkY95rLcxh66N4Sl96+7hqAQ==",
       "license": "MIT",
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
@@ -1878,7 +1886,9 @@
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "9.3.3",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.3.6.tgz",
+      "integrity": "sha512-tGm7FGWPmJKxGZMvkRPRi219x3tKmBxR7Uke09nTp2ujNak/O5V9xPIQ9lUBGTxqAb8U2yjKkXG8j+f/4b2+sw==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/types": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "vite": "^8.2.0"
   },
   "dependencies": {
-    "@deck.gl/core": "^9.3.7",
-    "@deck.gl/geo-layers": "^9.3.8",
-    "@deck.gl/google-maps": "^9.3.7",
-    "@deck.gl/layers": "^9.3.7",
+    "@deck.gl/core": "^9.3.10",
+    "@deck.gl/geo-layers": "^9.3.10",
+    "@deck.gl/google-maps": "^9.3.10",
+    "@deck.gl/layers": "^9.3.10",
     "@loaders.gl/kml": "^4.4.4",
     "@vis.gl/react-google-maps": "1.8.3",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
This PR does the following things:

1. **`package.json`**: Explicitly bumped `@deck.gl/core`, `@deck.gl/geo-layers`, `@deck.gl/google-maps`, and `@deck.gl/layers` to `^9.3.10` so they are perfectly aligned.
2. **`package-lock.json`**: Ran `npm install` to update the lockfile and safely pull down the matching dependencies.
3. **`.github/dependabot.yml`**: Configured a new Dependabot Group under the `npm` ecosystem that targets `"@deck.gl/*"`. Moving forward, Dependabot will always bundle all deck.gl package updates into a single atomic Pull Request, preventing them from falling out of sync again.