### PR TITLE
fix: Fixes incorrect region tag in HTML file.

### DIFF
--- a/samples/rgm-autocomplete/index.html
+++ b/samples/rgm-autocomplete/index.html
@@ -4,7 +4,7 @@
  Copyright 2026 Google LLC. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 -->
-<!-- [START maps_react_place_autocomplete_map] -->
+<!-- [START maps_rgm_autocomplete] -->
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -32,4 +32,4 @@
         <div id="app"></div>
     </body>
 </html>
-<!-- [END maps_react_place_autocomplete_map] -->
+<!-- [END maps_rgm_autocomplete] -->


### PR DESCRIPTION
This PR fixes an oopsie in the HTML file for rgm-autocomplete. It should follow the same convention as the other files (`maps_sample_name`).