### PR TITLE
fix(routes-compute-routes): resolve API validation errors on optional dropdowns

### DIFF
--- a/samples/routes-compute-routes/index.ts
+++ b/samples/routes-compute-routes/index.ts
@@ -128,11 +128,18 @@ async function init() {
                 (input) => (input as HTMLInputElement).value
             ),
             travelMode,
-            routingPreference: (formData.get('routing_preference') ??
-                undefined) as
-                google.maps.routes.RoutingPreferenceString | undefined,
-            polylineQuality: (formData.get('polyline_quality') ?? undefined) as
-                google.maps.routes.PolylineQualityString | undefined,
+            routingPreference:
+                (formData.get('routing_preference') as string) === ''
+                    ? undefined
+                    : (formData.get(
+                          'routing_preference'
+                      ) as google.maps.routes.RoutingPreferenceString),
+            polylineQuality:
+                (formData.get('polyline_quality') as string) === ''
+                    ? undefined
+                    : (formData.get(
+                          'polyline_quality'
+                      ) as google.maps.routes.PolylineQualityString),
             computeAlternativeRoutes:
                 formData.get('compute_alternative_routes') === 'on',
             routeModifiers: {
@@ -181,9 +188,12 @@ async function init() {
                 (input) =>
                     (input as HTMLInputElement).value as google.maps.TransitMode
             );
-            transitPreference.routingPreference = formData.get(
-                'transit_preference'
-            ) as google.maps.TransitRoutePreferenceString;
+            transitPreference.routingPreference =
+                (formData.get('transit_preference') as string) === ''
+                    ? undefined
+                    : (formData.get(
+                          'transit_preference'
+                      ) as google.maps.TransitRoutePreferenceString);
         }
 
         return request;


### PR DESCRIPTION
### What this PR does
Fixes an `InvalidValueError` thrown by the Routes API in the `routes-compute-routes` sample when submitting the form without selecting optional preferences. 

### Root Cause
In a previous chore update (#1574), new ESLint rules (`@typescript-eslint/prefer-nullish-coalescing`) prompted a switch from logical OR (`||`) to nullish coalescing (`??`) for handling optional `<select>` inputs. 

Because `FormData.get()` returns an empty string (`""`) for default unselected options, the nullish coalescing operator (`"" ?? undefined`) evaluated to `""` instead of `undefined`. This sent an invalid empty string value to the Maps API for enum fields, causing the validation error.

### The Fix
Replaced the `??` fallback logic with explicit ternary operators (`value === '' ? undefined : value`) for the following optional fields:
- `routingPreference`
- `polylineQuality`
- `transitPreference.routingPreference`

This ensures that empty strings correctly fall back to `undefined` before being sent to the API, while still satisfying the strict ESLint rules that prohibit the legacy `||` pattern.

Change-Id: Ifa79159c75cd2da592071c0d7cb4b20975fb5a8e